### PR TITLE
Cross-platform installation and script improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ wheels/
 # IDE
 .idea/
 .vscode/
+.cursor/
 *.swp
 *.swo
 *~

--- a/PLUGIN_DEVELOPMENT.md
+++ b/PLUGIN_DEVELOPMENT.md
@@ -156,7 +156,7 @@ Once your code is written, you must install the plugin in "editable" mode so the
 
 1.  **Activate your environment**:
     ```bash
-    source venv/bin/activate
+    source venv/bin/activate   # Windows: .\venv\Scripts\Activate.ps1
     ```
 
 2.  **Install your plugin**:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ tangled/
 │   └── src/tangled_block_visualizer/
 ├── graph-explorer/           # Flask web application
 │   └── src/tangled_graph_explorer/
-├── install.sh                # Installation script
+├── install.sh                # Installation script (Linux/macOS)
+├── install.ps1               # Installation script (Windows)
+├── reinstall.sh              # Reinstall all components (Linux/macOS)
+├── reinstall.ps1             # Reinstall all components (Windows)
+├── PLUGIN_DEVELOPMENT.md     # Guide for adding plugins
 └── README.md                 # This file
 ```
 
@@ -43,33 +47,48 @@ tangled/
 ## Requirements
 
 - Python 3.10+
-- pip
 
 ## Installation
 
-### Quick Start
+### Linux / macOS
+
+In terminal:
 
 ```bash
-# Clone the repository
-git clone <repo-url>
+git clone https://github.com/re-pixel/tangled.git
 cd tangled
 
-# Run the install script
 ./install.sh
-
-# Start the application
+source venv/bin/activate
 tangled
-# or: flask --app tangled_graph_explorer run --debug
 ```
+
+Open http://localhost:5000 in your browser.
+
+### Windows
+
+In PowerShell:
+
+```powershell
+git clone https://github.com/re-pixel/tangled.git
+cd tangled
+
+.\install.ps1
+.\venv\Scripts\Activate.ps1
+tangled
+```
+
+If script execution is disabled, run once: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
+
+Open http://localhost:5000 in your browser.
 
 ### Manual Installation
 
-```bash
-# Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+If you prefer not to use the install script (any platform):
 
-# Install components in dependency order
+```bash
+python -m venv venv
+source venv/bin/activate   # Windows: .\venv\Scripts\Activate.ps1
 pip install -e ./api
 pip install -e ./platform
 pip install -e ./json-datasource
@@ -77,8 +96,6 @@ pip install -e ./xml-datasource
 pip install -e ./simple-visualizer
 pip install -e ./block-visualizer
 pip install -e ./graph-explorer
-
-# Run the application
 tangled
 ```
 
@@ -92,10 +109,22 @@ When you modify a component, reinstall it:
 pip install -e ./platform  # or whichever component you changed
 ```
 
-Or use the reinstall script:
+Or use the reinstall script (with venv activated, or from project root):
+
+### Linux / macOS
+
+In terminal:
 
 ```bash
 ./reinstall.sh
+```
+
+### Windows
+
+In PowerShell:
+
+```powershell
+.\reinstall.ps1
 ```
 
 ### Adding a New Plugin

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Open http://localhost:5000 in your browser.
 If you prefer not to use the install script (any platform):
 
 ```bash
-python -m venv venv
+python3 -m venv venv
 source venv/bin/activate   # Windows: .\venv\Scripts\Activate.ps1
 pip install -e ./api
 pip install -e ./platform

--- a/graph-explorer/README.md
+++ b/graph-explorer/README.md
@@ -14,31 +14,27 @@ Flask web application for interactive graph visualization.
 
 ## Installation
 
-First, install all components in development mode:
+From the repository root, install all components and activate the venv:
 
+**Linux / macOS:**
 ```bash
-# From the repository root
 ./install.sh
-
-# Or manually:
-pip install -e ./api
-pip install -e ./platform
-pip install -e ./json-datasource
-pip install -e ./xml-datasource
-pip install -e ./simple-visualizer
-pip install -e ./block-visualizer
-pip install -e ./graph-explorer
+source venv/bin/activate
 ```
+
+**Windows (PowerShell):**
+```powershell
+.\install.ps1
+.\venv\Scripts\Activate.ps1
+```
+
+**Or install manually** (any platform): create venv, activate it, then `pip install -e ./api` (and the rest; see main [README](../README.md)).
 
 ## Running the Application
 
 ```bash
-# Using the CLI command
 tangled
-
-# Or directly with Flask
-cd graph-explorer
-flask --app tangled_graph_explorer run --debug
+# Or: flask --app tangled_graph_explorer run --debug
 ```
 
 Then open http://localhost:5000 in your browser.

--- a/install.ps1
+++ b/install.ps1
@@ -4,6 +4,11 @@
 
 $ErrorActionPreference = "Stop"
 
+if (-not (Test-Path ".\api")) {
+    Write-Host "Error: Run this script from the repository root (the folder containing api, platform, etc.)." -ForegroundColor Red
+    exit 1
+}
+
 Write-Host "========================================="
 Write-Host "Tangled Graph Explorer - Installation"
 Write-Host "========================================="
@@ -43,7 +48,7 @@ Write-Host "Python $pythonVersion detected" -ForegroundColor Green
 Write-Host ""
 
 # Check if venv and ensurepip are available
-& $Py $PyArgs -c "import venv, ensurepip" 2>&1 | Out-Null
+& $Py $PyArgs -c "import venv, ensurepip" 2>$null
 if ($LASTEXITCODE -ne 0) {
     Write-Host "Error: venv/ensurepip is not available." -ForegroundColor Red
     Write-Host "Reinstall Python from https://www.python.org/downloads/ and run the installer again."
@@ -70,21 +75,36 @@ if ($LASTEXITCODE -ne 0) { exit 1 }
 Write-Host "pip upgraded" -ForegroundColor Green
 Write-Host ""
 
+# Discover components: direct subdirs with pyproject.toml, order api → platform → others (sorted) → graph-explorer
+$middle = Get-ChildItem -Directory | Where-Object {
+    $_.Name -notin @("api", "platform", "graph-explorer", "venv") -and
+    (Test-Path (Join-Path $_.FullName "pyproject.toml"))
+} | Select-Object -ExpandProperty Name | Sort-Object
+$componentDirs = @("api", "platform") + [array]$middle
+if (Test-Path ".\graph-explorer\pyproject.toml") { $componentDirs += "graph-explorer" }
+$componentPaths = $componentDirs | ForEach-Object { ".\$_" }
+
+# Get package name from pyproject.toml (fallback: tangled-<dirname>)
+function Get-PackageName($dir) {
+    $pyproject = Join-Path $dir "pyproject.toml"
+    if (-not (Test-Path $pyproject)) { return "tangled-$dir" }
+    $content = Get-Content $pyproject -Raw -ErrorAction SilentlyContinue
+    if ($content -match 'name\s*=\s*"([^"]+)"') { return $Matches[1] }
+    if ($content -match "name\s*=\s*'([^']+)'") { return $Matches[1] }
+    return "tangled-$dir"
+}
+
 Write-Host "Installing components..."
-$components = @(
-    @{ n = "1/7"; name = "tangled-api"; path = ".\api" },
-    @{ n = "2/7"; name = "tangled-platform"; path = ".\platform" },
-    @{ n = "3/7"; name = "tangled-json-datasource"; path = ".\json-datasource" },
-    @{ n = "4/7"; name = "tangled-xml-datasource"; path = ".\xml-datasource" },
-    @{ n = "5/7"; name = "tangled-simple-visualizer"; path = ".\simple-visualizer" },
-    @{ n = "6/7"; name = "tangled-block-visualizer"; path = ".\block-visualizer" },
-    @{ n = "7/7"; name = "tangled-graph-explorer"; path = ".\graph-explorer" }
-)
-foreach ($c in $components) {
-    Write-Host "  [$($c.n)] Installing $($c.name)..."
-    & $pip install -e $c.path --quiet
+$total = $componentPaths.Count
+$n = 0
+foreach ($path in $componentPaths) {
+    $n++
+    $dirName = Split-Path -Leaf $path
+    $pkg = Get-PackageName $dirName
+    Write-Host "  [$n/$total] Installing $pkg..."
+    & $pip install -e $path --quiet
     if ($LASTEXITCODE -ne 0) { exit 1 }
-    Write-Host "  $($c.name) installed" -ForegroundColor Green
+    Write-Host "  $pkg installed" -ForegroundColor Green
 }
 
 Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,104 @@
+# Tangled Graph Explorer - Installation Script (Windows)
+# This script sets up the complete development environment.
+# Run in PowerShell: .\install.ps1
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "========================================="
+Write-Host "Tangled Graph Explorer - Installation"
+Write-Host "========================================="
+Write-Host ""
+
+# Find Python (try 'python', then 'py -3')
+$Py = $null
+$PyArgs = @()
+if (Get-Command python -ErrorAction SilentlyContinue) {
+    $Py = "python"
+    $PyArgs = @()
+} elseif (Get-Command py -ErrorAction SilentlyContinue) {
+    $Py = "py"
+    $PyArgs = @("-3")
+} else {
+    Write-Host "Error: Python not found. Install Python 3.10+ from https://www.python.org/downloads/ and ensure 'Add Python to PATH' is checked." -ForegroundColor Red
+    exit 1
+}
+
+# Get version (e.g. "Python 3.12.3" -> 3.12)
+$versionOutput = & $Py $PyArgs --version 2>&1 | Out-String
+if ($versionOutput -match "Python (\d+\.\d+)") {
+    $pythonVersion = $Matches[1]
+} else {
+    Write-Host "Error: Could not detect Python version." -ForegroundColor Red
+    exit 1
+}
+
+$required = [version]"3.10"
+$current = [version]($pythonVersion + ".0")
+if ($current -lt $required) {
+    Write-Host "Error: Python 3.10 or higher is required (found $pythonVersion)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Python $pythonVersion detected" -ForegroundColor Green
+Write-Host ""
+
+# Check if venv and ensurepip are available
+& $Py $PyArgs -c "import venv, ensurepip" 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: venv/ensurepip is not available." -ForegroundColor Red
+    Write-Host "Reinstall Python from https://www.python.org/downloads/ and run the installer again."
+    Write-Host "Ensure you check 'Add Python to PATH' and that pip is installed (default)." -ForegroundColor Yellow
+    exit 1
+}
+
+# Create virtual environment if it doesn't exist
+if (-not (Test-Path "venv")) {
+    Write-Host "Creating virtual environment..."
+    & $Py $PyArgs -m venv venv
+    if ($LASTEXITCODE -ne 0) { exit 1 }
+    Write-Host "Virtual environment created" -ForegroundColor Green
+}
+Write-Host ""
+
+# Use venv's pip directly (no activation needed in script)
+$pip = ".\venv\Scripts\pip.exe"
+$python = ".\venv\Scripts\python.exe"
+
+Write-Host "Upgrading pip..."
+& $pip install --upgrade pip --quiet
+if ($LASTEXITCODE -ne 0) { exit 1 }
+Write-Host "pip upgraded" -ForegroundColor Green
+Write-Host ""
+
+Write-Host "Installing components..."
+$components = @(
+    @{ n = "1/7"; name = "tangled-api"; path = ".\api" },
+    @{ n = "2/7"; name = "tangled-platform"; path = ".\platform" },
+    @{ n = "3/7"; name = "tangled-json-datasource"; path = ".\json-datasource" },
+    @{ n = "4/7"; name = "tangled-xml-datasource"; path = ".\xml-datasource" },
+    @{ n = "5/7"; name = "tangled-simple-visualizer"; path = ".\simple-visualizer" },
+    @{ n = "6/7"; name = "tangled-block-visualizer"; path = ".\block-visualizer" },
+    @{ n = "7/7"; name = "tangled-graph-explorer"; path = ".\graph-explorer" }
+)
+foreach ($c in $components) {
+    Write-Host "  [$($c.n)] Installing $($c.name)..."
+    & $pip install -e $c.path --quiet
+    if ($LASTEXITCODE -ne 0) { exit 1 }
+    Write-Host "  $($c.name) installed" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "========================================="
+Write-Host "Installation complete!"
+Write-Host "========================================="
+Write-Host ""
+Write-Host "To start the application:" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  .\venv\Scripts\Activate.ps1"
+Write-Host "  tangled"
+Write-Host ""
+Write-Host "Or run without activating:"
+Write-Host "  .\venv\Scripts\tangled.exe"
+Write-Host ""
+Write-Host "Then open http://localhost:5000 in your browser." -ForegroundColor Cyan
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,13 @@ fi
 
 echo "✓ Python $PYTHON_VERSION detected"
 
+# Check if venv module is available
+if ! python3 -c "import venv, ensurepip" 2>/dev/null; then
+    echo "Error: python3-venv is not installed."
+    echo "Run: sudo apt install python3.${PYTHON_VERSION#*.}-venv"
+    exit 1
+fi
+
 # Create virtual environment if it doesn't exist
 if [ ! -d "venv" ]; then
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -47,37 +47,37 @@ echo "Upgrading pip..."
 pip install --upgrade pip --quiet
 echo "✓ pip upgraded"
 
+# Discover components: direct subdirs with pyproject.toml, order api → platform → others (sorted) → graph-explorer
+COMPONENTS="api platform"
+MIDDLE=$(for d in */; do
+  d="${d%/}"
+  [ "$d" = "api" ] || [ "$d" = "platform" ] || [ "$d" = "graph-explorer" ] || [ "$d" = "venv" ] && continue
+  [ -f "$d/pyproject.toml" ] && echo "$d"
+done | sort)
+[ -f "graph-explorer/pyproject.toml" ] && COMPONENTS="$COMPONENTS $MIDDLE graph-explorer" || COMPONENTS="$COMPONENTS $MIDDLE"
+COMPONENTS=$(echo $COMPONENTS | xargs)
+
+# Get package name from pyproject.toml (fallback: tangled-<dirname>)
+get_pkg_name() {
+  local f="$1/pyproject.toml" pkg
+  pkg=$(sed -n 's/^name[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$f" 2>/dev/null)
+  [ -z "$pkg" ] && pkg=$(sed -n "s/^name[[:space:]]*=[[:space:]]*'\([^']*\)'.*/\1/p" "$f" 2>/dev/null)
+  [ -z "$pkg" ] && pkg="tangled-$1"
+  echo "$pkg"
+}
+
 # Install components in dependency order
 echo ""
 echo "Installing components..."
-
-echo "  [1/7] Installing tangled-api..."
-pip install -e ./api --quiet
-echo "  ✓ tangled-api installed"
-
-echo "  [2/7] Installing tangled-platform..."
-pip install -e ./platform --quiet
-echo "  ✓ tangled-platform installed"
-
-echo "  [3/7] Installing tangled-json-datasource..."
-pip install -e ./json-datasource --quiet
-echo "  ✓ tangled-json-datasource installed"
-
-echo "  [4/7] Installing tangled-xml-datasource..."
-pip install -e ./xml-datasource --quiet
-echo "  ✓ tangled-xml-datasource installed"
-
-echo "  [5/7] Installing tangled-simple-visualizer..."
-pip install -e ./simple-visualizer --quiet
-echo "  ✓ tangled-simple-visualizer installed"
-
-echo "  [6/7] Installing tangled-block-visualizer..."
-pip install -e ./block-visualizer --quiet
-echo "  ✓ tangled-block-visualizer installed"
-
-echo "  [7/7] Installing tangled-graph-explorer..."
-pip install -e ./graph-explorer --quiet
-echo "  ✓ tangled-graph-explorer installed"
+n=0
+total=$(echo $COMPONENTS | wc -w)
+for dir in $COMPONENTS; do
+  n=$((n + 1))
+  pkg=$(get_pkg_name "$dir")
+  echo "  [$n/$total] Installing $pkg..."
+  pip install -e "./$dir" --quiet
+  echo "  ✓ $pkg installed"
+done
 
 echo ""
 echo "========================================="

--- a/install.sh
+++ b/install.sh
@@ -22,8 +22,20 @@ echo "✓ Python $PYTHON_VERSION detected"
 
 # Check if venv module is available
 if ! python3 -c "import venv, ensurepip" 2>/dev/null; then
-    echo "Error: python3-venv is not installed."
-    echo "Run: sudo apt install python3.${PYTHON_VERSION#*.}-venv"
+    echo "Error: Python venv/ensurepip modules are not available."
+    if command -v apt-get >/dev/null 2>&1 || [ -f /etc/debian_version ]; then
+        echo "On Debian/Ubuntu run: sudo apt install python3.${PYTHON_VERSION#*.}-venv"
+    elif [ -f /etc/redhat-release ] && command -v dnf >/dev/null 2>&1; then
+        echo "On Fedora/RHEL run: sudo dnf install python3-virtualenv"
+    elif [ -f /etc/arch-release ]; then
+        echo "On Arch Linux run: sudo pacman -S python-venv"
+    elif command -v zypper >/dev/null 2>&1; then
+        echo "On openSUSE run: sudo zypper install python3-venv"
+    elif [ "$(uname -s)" = "Darwin" ]; then
+        echo "On macOS run: brew install python"
+    else
+        echo "Install the venv package for your Python version using your system package manager."
+    fi
     exit 1
 fi
 

--- a/reinstall.ps1
+++ b/reinstall.ps1
@@ -4,6 +4,11 @@
 
 $ErrorActionPreference = "Stop"
 
+if (-not (Test-Path ".\api")) {
+    Write-Host "Error: Run this script from the repository root (the folder containing api, platform, etc.)." -ForegroundColor Red
+    exit 1
+}
+
 Write-Host "Reinstalling all Tangled components..." -ForegroundColor Cyan
 Write-Host ""
 
@@ -14,29 +19,44 @@ if (-not (Test-Path "venv")) {
 
 $pip = ".\venv\Scripts\pip.exe"
 
-# Uninstall existing packages
+# Discover components (same order as install.ps1): api → platform → others (sorted) → graph-explorer
+$middle = Get-ChildItem -Directory | Where-Object {
+    $_.Name -notin @("api", "platform", "graph-explorer", "venv") -and
+    (Test-Path (Join-Path $_.FullName "pyproject.toml"))
+} | Select-Object -ExpandProperty Name | Sort-Object
+$componentDirs = @("api", "platform") + [array]$middle
+if (Test-Path ".\graph-explorer\pyproject.toml") { $componentDirs += "graph-explorer" }
+$componentPaths = $componentDirs | ForEach-Object { ".\$_" }
+
+# Get package name from pyproject.toml (fallback: tangled-<dirname>)
+function Get-PackageName($dir) {
+    $pyproject = Join-Path $dir "pyproject.toml"
+    if (-not (Test-Path $pyproject)) { return "tangled-$dir" }
+    $content = Get-Content $pyproject -Raw -ErrorAction SilentlyContinue
+    if ($content -match 'name\s*=\s*"([^"]+)"') { return $Matches[1] }
+    if ($content -match "name\s*=\s*'([^']+)'") { return $Matches[1] }
+    return "tangled-$dir"
+}
+
+# Uninstall existing packages (use name from each pyproject.toml)
+$packageNames = $componentDirs | ForEach-Object { Get-PackageName $_ }
 Write-Host "Removing existing installations..."
-& $pip uninstall -y tangled-api tangled-platform tangled-json-datasource tangled-xml-datasource tangled-simple-visualizer tangled-block-visualizer tangled-graph-explorer 2>$null
+& $pip uninstall -y @packageNames 2>$null
 # pip uninstall may return non-zero if a package wasn't installed; script continues
 
-# Clean build artifacts
+# Clean build artifacts (only in component dirs, not venv)
 Write-Host "Cleaning build artifacts..."
-Get-ChildItem -Path . -Recurse -Directory -Filter "*.egg-info" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-Get-ChildItem -Path . -Recurse -Directory -Filter "build" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-Get-ChildItem -Path . -Recurse -Directory -Filter "__pycache__" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+foreach ($path in $componentPaths) {
+    if (Test-Path $path) {
+        Get-ChildItem -Path $path -Recurse -Directory -Filter "*.egg-info" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        Get-ChildItem -Path $path -Recurse -Directory -Filter "build" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        Get-ChildItem -Path $path -Recurse -Directory -Filter "__pycache__" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
 
 # Reinstall
 Write-Host "Reinstalling components..."
-$components = @(
-    ".\api",
-    ".\platform",
-    ".\json-datasource",
-    ".\xml-datasource",
-    ".\simple-visualizer",
-    ".\block-visualizer",
-    ".\graph-explorer"
-)
-foreach ($path in $components) {
+foreach ($path in $componentPaths) {
     & $pip install -e $path --quiet
     if ($LASTEXITCODE -ne 0) { exit 1 }
 }

--- a/reinstall.ps1
+++ b/reinstall.ps1
@@ -1,0 +1,48 @@
+# Tangled Graph Explorer - Reinstall Script (Windows)
+# Use this to reinstall all components after making changes.
+# Run in PowerShell: .\reinstall.ps1
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Reinstalling all Tangled components..." -ForegroundColor Cyan
+Write-Host ""
+
+if (-not (Test-Path "venv")) {
+    Write-Host "Error: Virtual environment not found. Run install.ps1 first." -ForegroundColor Red
+    exit 1
+}
+
+$pip = ".\venv\Scripts\pip.exe"
+
+# Uninstall existing packages
+Write-Host "Removing existing installations..."
+& $pip uninstall -y tangled-api tangled-platform tangled-json-datasource tangled-xml-datasource tangled-simple-visualizer tangled-block-visualizer tangled-graph-explorer 2>$null
+# pip uninstall may return non-zero if a package wasn't installed; script continues
+
+# Clean build artifacts
+Write-Host "Cleaning build artifacts..."
+Get-ChildItem -Path . -Recurse -Directory -Filter "*.egg-info" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+Get-ChildItem -Path . -Recurse -Directory -Filter "build" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+Get-ChildItem -Path . -Recurse -Directory -Filter "__pycache__" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
+# Reinstall
+Write-Host "Reinstalling components..."
+$components = @(
+    ".\api",
+    ".\platform",
+    ".\json-datasource",
+    ".\xml-datasource",
+    ".\simple-visualizer",
+    ".\block-visualizer",
+    ".\graph-explorer"
+)
+foreach ($path in $components) {
+    & $pip install -e $path --quiet
+    if ($LASTEXITCODE -ne 0) { exit 1 }
+}
+
+Write-Host ""
+Write-Host "All components reinstalled!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Starting server..."
+& .\venv\Scripts\tangled.exe

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+if [ ! -d "api" ]; then
+    echo "Error: Run this script from the repository root."
+    exit 1
+fi
+
 echo "Reinstalling all Tangled components..."
 
 # Activate virtual environment

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -15,25 +15,45 @@ fi
 
 source venv/bin/activate
 
-# Uninstall existing packages
-echo "Removing existing installations..."
-pip uninstall -y tangled-api tangled-platform tangled-json-datasource tangled-xml-datasource tangled-simple-visualizer tangled-block-visualizer tangled-graph-explorer 2>/dev/null || true
+# Discover components (same order as install.sh): api → platform → others (sorted) → graph-explorer
+COMPONENTS="api platform"
+MIDDLE=$(for d in */; do
+  d="${d%/}"
+  [ "$d" = "api" ] || [ "$d" = "platform" ] || [ "$d" = "graph-explorer" ] || [ "$d" = "venv" ] && continue
+  [ -f "$d/pyproject.toml" ] && echo "$d"
+done | sort)
+[ -f "graph-explorer/pyproject.toml" ] && COMPONENTS="$COMPONENTS $MIDDLE graph-explorer" || COMPONENTS="$COMPONENTS $MIDDLE"
+COMPONENTS=$(echo $COMPONENTS | xargs)
 
-# Clean build artifacts
+# Get package name from pyproject.toml (fallback: tangled-<dirname>)
+get_pkg_name() {
+  local f="$1/pyproject.toml" pkg
+  pkg=$(sed -n 's/^name[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$f" 2>/dev/null)
+  [ -z "$pkg" ] && pkg=$(sed -n "s/^name[[:space:]]*=[[:space:]]*'\([^']*\)'.*/\1/p" "$f" 2>/dev/null)
+  [ -z "$pkg" ] && pkg="tangled-$1"
+  echo "$pkg"
+}
+
+# Uninstall existing packages (use name from each pyproject.toml)
+echo "Removing existing installations..."
+for dir in $COMPONENTS; do
+  pkg=$(get_pkg_name "$dir")
+  pip uninstall -y "$pkg" 2>/dev/null || true
+done
+
+# Clean build artifacts (only in component dirs, not venv)
 echo "Cleaning build artifacts..."
-find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
-find . -type d -name "build" -exec rm -rf {} + 2>/dev/null || true
-find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+for dir in $COMPONENTS; do
+  [ -d "$dir" ] && find "$dir" -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+  [ -d "$dir" ] && find "$dir" -type d -name "build" -exec rm -rf {} + 2>/dev/null || true
+  [ -d "$dir" ] && find "$dir" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+done
 
 # Reinstall
 echo "Reinstalling components..."
-pip install -e ./api --quiet
-pip install -e ./platform --quiet
-pip install -e ./json-datasource --quiet
-pip install -e ./xml-datasource --quiet
-pip install -e ./simple-visualizer --quiet
-pip install -e ./block-visualizer --quiet
-pip install -e ./graph-explorer --quiet
+for dir in $COMPONENTS; do
+  pip install -e "./$dir" --quiet
+done
 
 echo ""
 echo "✓ All components reinstalled!"


### PR DESCRIPTION
closes #7 

This PR improves installation and reinstallation on all platforms and makes the scripts maintainable when adding new plugins.

### Summary of changes

**1. Debian/Ubuntu support (`install.sh`)**  
- Check that both `venv` and `ensurepip` are available before creating the venv.  
- If the check fails, print a clear error and the exact `apt install python3.x-venv` command (using the detected Python minor version).  
- Prevents the script from failing halfway with a Python traceback on minimal Python installs.

**2. Windows support**  
- **`install.ps1`:** Detects Python (`python` or `py -3`), checks version (3.10+), verifies venv/ensurepip, creates venv, upgrades pip, discovers components, and installs them. Includes a repo-root check and uses `2>$null` for the venv check so `$LASTEXITCODE` is reliable.  
- **`reinstall.ps1`:** Same discovery and ordering; uninstalls by package name from `pyproject.toml`, cleans only component dirs (not venv), reinstalls, then starts the app.  
- Both scripts assume “run from repo root” and exit with a clear message if not.

**3. Component discovery and package names**  
- **Discovery:** Components are no longer hardcoded. Scripts discover direct subdirs that contain a `pyproject.toml`, with fixed order: `api` → `platform` → other plugins (sorted) → `graph-explorer`. `venv` is excluded.  
- **Package names:** The package name used for uninstall and for progress messages is read from each component’s `[project] name` in `pyproject.toml` (with fallback to `tangled-<dirname>` if parsing fails), matching the spec’s “meaningful names” for plugins.  
- **Reinstall clean:** Clean step is limited to discovered component directories only (no cleaning inside `venv`).  
- **Bash:** `get_pkg_name()` in install.sh and reinstall.sh; reinstall.sh uses it for `pip uninstall`.  
- **PowerShell:** `Get-PackageName` in install.ps1 and reinstall.ps1; reinstall.ps1 builds the uninstall list from it.

**4. Documentation**  
- **README:** Platform-specific installation (Linux/macOS with `./install.sh` + activate; Windows with `.\install.ps1` + activate). Manual installation and reinstall section updated with Windows (`.\reinstall.ps1`). Project structure updated (install/reinstall scripts, `.gitignore`, `PLUGIN_DEVELOPMENT.md`, `specification.md`). Requirements clarified (Python 3.10+, venv; no global pip required).  
- **PLUGIN_DEVELOPMENT.md:** Windows venv activation note (`.\venv\Scripts\Activate.ps1`).  
- **graph-explorer/README.md:** Install/run instructions for Linux/macOS and Windows; link to main README for manual steps.

**5. Other**  
- `.gitignore`: added `.cursor/`.

### Commits

1. **fix: add install.sh support for debian/ubuntu** – Venv/ensurepip check and clear apt hint.  
2. **chore: add installation and reinstallation scripts for Windows** – `install.ps1`, `reinstall.ps1`.  
3. **feat: update installation instructions for cross platform support** – README, PLUGIN_DEVELOPMENT.md, graph-explorer README, .gitignore.  
4. **feat: enhance installation and reinstallation scripts by component discovery** – Discovery, repo-root checks, package names from pyproject.toml, venv-safe clean.
