### PR TITLE
Block Visualizer Plugin

### DIFF
--- a/block-visualizer/README.md
+++ b/block-visualizer/README.md
@@ -4,10 +4,12 @@ Detailed visualizer that displays graph nodes as rectangles showing all attribut
 
 ## Features
 
-- Nodes displayed as rectangles/blocks
-- Shows node ID/name as header
-- Lists all attributes with their values
-- Edges shown as lines connecting blocks
+- Nodes displayed as rectangles/blocks with a colored header
+- Header shows the node UUID/ID
+- Lists all node attributes as key-value rows
+- Alternating row background for readability
+- Edges shown as lines connecting blocks (with arrowheads for directed graphs)
+- Visibility culling — only nodes in the current viewport are rendered
 - Ideal for detailed data inspection
 
 ## Installation
@@ -31,9 +33,98 @@ workspace.load_data(...)
 html = workspace.render(platform.get_visualizer("block"))
 ```
 
+## How It Works
+
+### Python Side (`__init__.py`)
+
+`BlockVisualizer` implements `VisualizerPlugin` and is responsible for serializing the graph into JSON and injecting it into the HTML template.
+
+For each node it produces:
+
+```json
+{
+  "id": "<node uuid>",
+  "label": "<value of first attribute, or node id if no attributes>",
+  "attributes": [
+    { "name": "attr_name", "value": "attr_value", "type": "string" }
+  ]
+}
+```
+
+For each edge:
+
+```json
+{
+  "id": "<edge id>",
+  "source": "<source node id>",
+  "target": "<target node id>",
+  "attributes": []
+}
+```
+
+`datetime` values are automatically converted to ISO 8601 strings via `.isoformat()`.
+
+The template receives:
+| Variable | Description |
+|----------|-------------|
+| `name` | Unique identifier for the SVG element (`id(graph)`) |
+| `nodes` | List of serialized node dicts |
+| `edges` | List of serialized edge dicts |
+| `directed` | Boolean — whether edges have direction |
+
+### Template Side (`template/template.html`)
+
+The template renders an `<svg>` element and a `<script>` block. On load, the script uses D3.js to build the SVG structure:
+
+- One `<g class="block-node" id="<node-id>">` per node containing:
+  - A border `<rect>` (white fill, blue stroke)
+  - A header `<rect>` (blue fill)
+  - A `<text>` for the node ID in the header
+  - One row per attribute: alternating background rect, divider line, name text, value text
+- One `<line class="plugin-link">` per edge
+
+Node dimensions are computed dynamically based on the number of attributes:
+
+```
+node height = HEADER_H (28px) + max(1, attr_count) * ROW_H (20px) + 4px
+node width  = max(160px, header_text_width + 2 * PAD_X)
+```
+
+The SVG element exposes two `data-` attributes consumed by `GraphRenderer`:
+
+```html
+<svg data-node-selector=".block-node" data-link-selector=".plugin-link"></svg>
+```
+
+These tell the platform JS which elements are nodes and which are edges, so it can attach the force simulation, drag, zoom, and culling.
+
+### Rendering Pipeline
+
+```
+BlockVisualizer.render(graph)
+    └── Jinja2 template renders HTML string
+            └── Injected into DOM by WorkspaceController
+                    └── GraphRenderer.attach() picks up .block-node / .plugin-link
+                            └── D3 force simulation + culling takes over
+```
+
 ## Output
 
-Generates HTML/SVG structure for D3.js rendering with:
-- Rectangle nodes with header and attribute list
-- Line edges connecting nodes
-- Data attributes for interactivity
+Generates an HTML fragment (no `<html>/<body>`) containing:
+
+- `<style>` block with scoped CSS
+- `<svg>` element with data attributes for GraphRenderer
+- `<script>` block that renders nodes/edges via D3.js on `document.fonts.ready`
+
+## File Structure
+
+```
+block-visualizer/
+├── __init__.py          # BlockVisualizer plugin class
+└── template/
+    └── template.html    # Jinja2 template (style + svg + d3 render script)
+```
+
+## Styling
+
+All colors are defined as CSS classes on SVG elements so they can be overridden.

--- a/block-visualizer/src/tangled_block_visualizer/plugin.py
+++ b/block-visualizer/src/tangled_block_visualizer/plugin.py
@@ -3,120 +3,82 @@ Block Visualizer Plugin implementation.
 """
 
 from typing import Any, Dict, List
-from jinja2 import Template
+from jinja2 import Environment, FileSystemLoader
+import os
 
 from tangled_api.model import Graph
 from tangled_api.plugins import VisualizerPlugin
 
 
-# Template for generating graph data structure for D3.js
-GRAPH_DATA_TEMPLATE = """
-<script type="application/json" id="graph-data-{{ graph_id }}">
-{
-    "nodes": [
-        {% for node in nodes %}
-        {
-            "id": "{{ node.id }}",
-            "label": "{{ node.label }}",
-            "attributes": [
-                {% for attr in node.attributes %}
-                {"name": "{{ attr.name }}", "value": "{{ attr.value }}", "type": "{{ attr.type }}"}{% if not loop.last %},{% endif %}
-                {% endfor %}
-            ]
-        }{% if not loop.last %},{% endif %}
-        {% endfor %}
-    ],
-    "edges": [
-        {% for edge in edges %}
-        {
-            "id": "{{ edge.id }}",
-            "source": "{{ edge.source }}",
-            "target": "{{ edge.target }}",
-            "attributes": [
-                {% for attr in edge.attributes %}
-                {"name": "{{ attr.name }}", "value": "{{ attr.value }}"}{% if not loop.last %},{% endif %}
-                {% endfor %}
-            ]
-        }{% if not loop.last %},{% endif %}
-        {% endfor %}
-    ]
-}
-</script>
-<div id="graph-container-{{ graph_id }}" class="graph-container block-visualizer" data-graph-id="{{ graph_id }}">
-    <!-- D3.js will render SVG here -->
-</div>
-"""
-
-
 class BlockVisualizer(VisualizerPlugin):
     """
     Block visualizer that displays nodes as rectangles with all attributes.
-    
+
     Generates HTML structure with embedded JSON data for D3.js rendering.
     The actual SVG rendering is handled by platform JavaScript.
     """
-    
+
+    def __init__(self) -> None:
+        template_path = os.path.join(os.path.dirname(__file__))
+        environment = Environment(
+            loader=FileSystemLoader(template_path + "/template"))
+        self.template = environment.get_template("template.html")
+
     @property
     def name(self) -> str:
         return "Block Visualizer"
-    
+
     @property
     def description(self) -> str:
         return "Displays nodes as rectangles with ID and all attributes listed."
-    
+
     def render(self, graph: Graph) -> str:
-        """
-        Generate HTML for block graph visualization.
-        
-        Args:
-            graph: The graph to visualize
-            
-        Returns:
-            HTML string with embedded graph data
-        """
-        template = Template(GRAPH_DATA_TEMPLATE)
-        
         nodes = []
         for node_id, node in graph.nodes.items():
-            # Get label from first attribute or ID
             label = node_id
             if node.attributes:
                 first_attr = next(iter(node.attributes.values()))
                 label = str(first_attr.value)
-            
-            # Collect all attributes with type info
+
             attributes = []
             for attr_name, attr in node.attributes.items():
+                value = attr.value
+                if hasattr(value, "isoformat"):
+                    value = value.isoformat()
                 attributes.append({
                     "name": attr_name,
-                    "value": str(attr.value),
+                    "value": str(value),
                     "type": attr.type.value,
                 })
-            
+
             nodes.append({
                 "id": node_id,
                 "label": label,
                 "attributes": attributes,
             })
-        
+
         edges = []
         for edge_id, edge in graph.edges.items():
             edge_attrs = []
             for attr_name, attr in edge.attributes.items():
+                value = attr.value
+                if hasattr(value, "isoformat"):
+                    value = value.isoformat()
                 edge_attrs.append({
                     "name": attr_name,
-                    "value": str(attr.value),
+                    "value": str(value),
                 })
-            
+
             edges.append({
                 "id": edge_id,
                 "source": edge.source_id,
                 "target": edge.target_id,
                 "attributes": edge_attrs,
             })
-        
-        return template.render(
-            graph_id=id(graph),
+
+        return self.template.render(
+            name=id(graph),
             nodes=nodes,
             edges=edges,
+            directed=graph.directed,
         )

--- a/block-visualizer/src/tangled_block_visualizer/template/template.html
+++ b/block-visualizer/src/tangled_block_visualizer/template/template.html
@@ -36,14 +36,6 @@
     stroke: #3a7bc8;
     stroke-width: 1.5px;
   }
-
-  /*
-   * Hide all nodes and links by default.
-   */
-  .block-node,
-  .plugin-link {
-    visibility: hidden;
-  }
 </style>
 
 <svg

--- a/block-visualizer/src/tangled_block_visualizer/template/template.html
+++ b/block-visualizer/src/tangled_block_visualizer/template/template.html
@@ -1,0 +1,210 @@
+<style>
+  .block-node {
+    cursor: pointer;
+  }
+
+  #svg-{{name}} {
+    width: 100%;
+    height: 100%;
+  }
+
+  .block-visualizer text {
+    font-family: Arial, sans-serif !important;
+    font-size: 11px !important;
+  }
+
+  /* Header background */
+  .block-visualizer .header-bg {
+    fill: #3a7bc8 !important;
+  }
+
+  /* Node border */
+  .block-visualizer .node-border {
+    fill: white;
+    stroke: #3a7bc8;
+    stroke-width: 1.5px;
+  }
+
+  /* Attribute names */
+  .block-visualizer .attr-name {
+    fill: #3a7bc8;
+    font-weight: 600;
+  }
+
+  /* Links */
+  .plugin-link {
+    stroke: #3a7bc8;
+    stroke-width: 1.5px;
+  }
+
+  /*
+   * Hide all nodes and links by default.
+   */
+  .block-node,
+  .plugin-link {
+    visibility: hidden;
+  }
+</style>
+
+<svg
+  id="svg-{{name}}"
+  class="block-visualizer"
+  data-node-selector=".block-node"
+  data-link-selector=".plugin-link"
+></svg>
+
+<script>
+  (function () {
+
+    const nodes = {{ nodes | tojson }};
+    const links = {{ edges | tojson }};
+
+    const HEADER_H = 28;
+    const ROW_H = 20;
+    const PAD_X = 14;
+    const KEY_W = 80;
+    const FONT_SIZE = 11;
+    const BLUE = '#3a7bc8';
+
+    function getAttrs(d) {
+      return (d.attributes || []).filter(a =>
+        a.value !== null &&
+        a.value !== undefined &&
+        String(a.value).trim() !== ''
+      );
+    }
+
+    function nodeHeight(d) {
+      return HEADER_H + Math.max(1, getAttrs(d).length) * ROW_H + 4;
+    }
+
+    function render() {
+
+      const svg = d3.select('#svg-{{name}}').attr('zoom', true);
+      const g = svg.append('g');
+
+      /* Links */
+      g.selectAll('.plugin-link')
+        .data(links)
+        .enter()
+        .append('line')
+        .attr('class', 'plugin-link');
+
+      const node = g.selectAll('.block-node')
+        .data(nodes)
+        .enter()
+        .append('g')
+        .attr('class', 'block-node')
+        .attr('id', d => d.id);
+
+      /* Header text */
+      node.append('text')
+        .attr('class', 'header-text')
+        .attr('text-anchor', 'middle')
+        .attr('dominant-baseline', 'middle')
+        .attr('font-size', 13)
+        .attr('font-weight', 'bold')
+        .attr('fill', '#ffffff')
+        .text(d => d.id);
+
+      node.each(function (d) {
+
+        const grp = d3.select(this);
+
+        const attrs = getAttrs(d);
+
+        const textEl = this.querySelector('.header-text');
+        const textW = textEl ? textEl.getComputedTextLength() : 100;
+
+        const nw = Math.max(160, textW + PAD_X * 2);
+        const nh = nodeHeight(d);
+        const topY = -nh / 2;
+
+        /* Node border */
+        grp.insert('rect', '.header-text')
+          .attr('class', 'node-border')
+          .attr('x', -nw / 2)
+          .attr('y', topY)
+          .attr('width', nw)
+          .attr('height', nh)
+          .attr('rx', 4)
+          .attr('ry', 4);
+
+        /* Header background */
+        grp.insert('rect', '.header-text')
+          .attr('class', 'header-bg')
+          .attr('x', -nw / 2)
+          .attr('y', topY)
+          .attr('width', nw)
+          .attr('height', HEADER_H)
+          .attr('rx', 4)
+          .attr('ry', 4);
+
+        /* Header patch */
+        grp.insert('rect', '.header-text')
+          .attr('class', 'header-bg')
+          .attr('x', -nw / 2)
+          .attr('y', topY + HEADER_H - 6)
+          .attr('width', nw)
+          .attr('height', 6);
+
+        /* Header text position */
+        grp.select('.header-text')
+          .attr('x', 0)
+          .attr('y', topY + HEADER_H / 2);
+
+        if (attrs.length === 0) {
+
+          grp.append('text')
+            .attr('x', 0)
+            .attr('y', topY + HEADER_H + ROW_H - 5)
+            .attr('text-anchor', 'middle')
+            .attr('fill', '#aaaaaa')
+            .text('(no attributes)');
+
+          return;
+        }
+
+        attrs.forEach((attr, i) => {
+
+          const rowY = topY + HEADER_H + i * ROW_H;
+
+          if (i % 2 === 1) {
+            grp.append('rect')
+              .attr('x', -nw / 2)
+              .attr('y', rowY)
+              .attr('width', nw)
+              .attr('height', ROW_H)
+              .style('fill', '#f5f9ff');
+          }
+
+          if (i > 0) {
+            grp.append('line')
+              .attr('x1', -nw / 2 + 4)
+              .attr('x2', nw / 2 - 4)
+              .attr('y1', rowY)
+              .attr('y2', rowY)
+              .style('stroke', BLUE)
+              .style('stroke-width', '0.5px');
+          }
+
+          grp.append('text')
+            .attr('class', 'attr-name')
+            .attr('x', -nw / 2 + PAD_X)
+            .attr('y', rowY + ROW_H - 6)
+            .text(String(attr.name));
+
+          grp.append('text')
+            .attr('x', -nw / 2 + PAD_X + KEY_W + 8)
+            .attr('y', rowY + ROW_H - 6)
+            .attr('fill', '#333')
+            .text(String(attr.value));
+        });
+
+      });
+    }
+
+    document.fonts.ready.then(() => render());
+
+  })();
+</script>

--- a/block-visualizer/tests/test_block_plugin.py
+++ b/block-visualizer/tests/test_block_plugin.py
@@ -1,0 +1,143 @@
+"""
+Tests for BlockVisualizer plugin.
+"""
+
+import pytest
+from datetime import date
+
+from tangled_api.model import Graph, Node, Edge
+from tangled_block_visualizer import BlockVisualizer
+
+
+@pytest.fixture
+def visualizer():
+    return BlockVisualizer()
+
+
+@pytest.fixture
+def simple_graph():
+    graph = Graph(directed=True)
+    node = Node(id="node-1")
+    node.set_attribute("name", "John")
+    node.set_attribute("age", 30)
+    graph.add_node(node)
+    return graph
+
+
+# --- render() base cases ---
+
+def test_render_returns_string(visualizer, simple_graph):
+    result = visualizer.render(simple_graph)
+    assert isinstance(result, str)
+
+
+def test_render_empty_graph_does_not_crash(visualizer):
+    graph = Graph(directed=True)
+    result = visualizer.render(graph)
+    assert isinstance(result, str)
+
+
+def test_render_contains_node_id(visualizer, simple_graph):
+    result = visualizer.render(simple_graph)
+    assert "node-1" in result
+
+
+def test_render_contains_attribute_name(visualizer, simple_graph):
+    result = visualizer.render(simple_graph)
+    assert "name" in result
+
+
+def test_render_contains_attribute_value(visualizer, simple_graph):
+    result = visualizer.render(simple_graph)
+    assert "John" in result
+
+
+def test_render_contains_integer_attribute(visualizer, simple_graph):
+    result = visualizer.render(simple_graph)
+    assert "30" in result
+
+
+# --- Multiple nodes ---
+
+def test_render_multiple_nodes(visualizer):
+    graph = Graph(directed=True)
+    for i in range(3):
+        node = Node(id=f"node-{i}")
+        node.set_attribute("label", f"Label {i}")
+        graph.add_node(node)
+
+    result = visualizer.render(graph)
+
+    assert "node-0" in result
+    assert "node-1" in result
+    assert "node-2" in result
+
+
+# --- Node without attributes ---
+
+def test_render_node_without_attributes(visualizer):
+    graph = Graph(directed=True)
+    graph.add_node(Node(id="empty-node"))
+
+    result = visualizer.render(graph)
+    assert "empty-node" in result
+
+
+# --- Different attribute types ---
+
+def test_render_float_attribute(visualizer):
+    graph = Graph(directed=True)
+    node = Node(id="n1")
+    node.set_attribute("score", 9.5)
+    graph.add_node(node)
+
+    result = visualizer.render(graph)
+    assert "9.5" in result
+
+
+def test_render_date_attribute_as_iso_string(visualizer):
+    graph = Graph(directed=True)
+    node = Node(id="n1")
+    node.set_attribute("birthday", date(1990, 5, 15))
+    graph.add_node(node)
+
+    result = visualizer.render(graph)
+    assert "1990-05-15" in result
+
+
+# --- Edges ---
+
+def test_render_with_edges_does_not_crash(visualizer):
+    graph = Graph(directed=True)
+    n1 = Node(id="n1")
+    n2 = Node(id="n2")
+    graph.add_node(n1)
+    graph.add_node(n2)
+    graph.add_edge(Edge(id="e1", source_id="n1", target_id="n2"))
+
+    result = visualizer.render(graph)
+    assert isinstance(result, str)
+
+
+def test_render_undirected_graph(visualizer):
+    graph = Graph(directed=False)
+    n1 = Node(id="n1")
+    n2 = Node(id="n2")
+    graph.add_node(n1)
+    graph.add_node(n2)
+    graph.add_edge(Edge(id="e1", source_id="n1", target_id="n2"))
+
+    result = visualizer.render(graph)
+    assert isinstance(result, str)
+
+
+# --- HTML structure ---
+
+def test_render_contains_svg(visualizer, simple_graph):
+    result = visualizer.render(simple_graph)
+    assert "<svg" in result
+
+
+def test_render_contains_script(visualizer, simple_graph):
+    result = visualizer.render(simple_graph)
+    assert "<script" in result

--- a/graph-explorer/src/tangled_graph_explorer/api.py
+++ b/graph-explorer/src/tangled_graph_explorer/api.py
@@ -214,18 +214,27 @@ def get_graph_data(workspace_id: str):
     
     nodes = []
     for node_id, node in ws.graph.nodes.items():
-        nodes.append({
-            "id": node_id,
-            "attributes": {k: str(v) for k, v in node.attributes.items()},
-        })
-    
+        attrs = {}
+        for k, attr in node.attributes.items():
+            value = attr.value
+            if hasattr(value, "isoformat"):
+                value = value.isoformat()
+            attrs[k] = {"value": str(value), "type": attr.type.value}
+        nodes.append({"id": node_id, "attributes": attrs})
+
     edges = []
     for edge_id, edge in ws.graph.edges.items():
+        attrs = {}
+        for k, attr in edge.attributes.items():
+            value = attr.value
+            if hasattr(value, "isoformat"):
+                value = value.isoformat()
+            attrs[k] = {"value": str(value), "type": attr.type.value}
         edges.append({
             "id": edge_id,
             "source": edge.source_id,
             "target": edge.target_id,
-            "attributes": {k: str(v) for k, v in edge.attributes.items()},
+            "attributes": attrs,
         })
     
     return jsonify({

--- a/graph-explorer/src/tangled_graph_explorer/static/css/style.css
+++ b/graph-explorer/src/tangled_graph_explorer/static/css/style.css
@@ -3,187 +3,195 @@
  */
 
 :root {
-    --primary-color: #4a90d9;
-    --secondary-color: #6c757d;
-    --background-color: #f8f9fa;
-    --surface-color: #ffffff;
-    --text-color: #212529;
-    --border-color: #dee2e6;
-    --success-color: #28a745;
-    --error-color: #dc3545;
+  --primary-color: #4a90d9;
+  --secondary-color: #6c757d;
+  --background-color: #f8f9fa;
+  --surface-color: #ffffff;
+  --text-color: #212529;
+  --border-color: #dee2e6;
+  --success-color: #28a745;
+  --error-color: #dc3545;
 }
 
 * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    background-color: var(--background-color);
-    color: var(--text-color);
-    line-height: 1.6;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  line-height: 1.6;
+}
+
+#main-graph-container svg text {
+  font-family: Arial, sans-serif !important;
 }
 
 /* Header */
 .app-header {
-    background-color: var(--primary-color);
-    color: white;
-    padding: 1rem 2rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  background-color: var(--primary-color);
+  color: white;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .app-header h1 {
-    font-size: 1.5rem;
+  font-size: 1.5rem;
 }
 
 .app-header h1 a {
-    color: white;
-    text-decoration: none;
+  color: white;
+  text-decoration: none;
 }
 
 .app-header nav a {
-    color: white;
-    text-decoration: none;
-    margin-left: 1.5rem;
-    opacity: 0.9;
+  color: white;
+  text-decoration: none;
+  margin-left: 1.5rem;
+  opacity: 0.9;
 }
 
 .app-header nav a:hover {
-    opacity: 1;
-    text-decoration: underline;
+  opacity: 1;
+  text-decoration: underline;
 }
 
 /* Main content */
 .app-main {
-    min-height: calc(100vh - 120px);
-    padding: 2rem;
+  min-height: calc(100vh - 120px);
+  padding: 2rem;
 }
 
 /* Footer */
 .app-footer {
-    background-color: var(--surface-color);
-    border-top: 1px solid var(--border-color);
-    padding: 1rem 2rem;
-    text-align: center;
-    color: var(--secondary-color);
+  background-color: var(--surface-color);
+  border-top: 1px solid var(--border-color);
+  padding: 1rem 2rem;
+  text-align: center;
+  color: var(--secondary-color);
 }
 
 /* Buttons */
 .btn {
-    display: inline-block;
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 1rem;
-    transition: background-color 0.2s;
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.2s;
 }
 
 .btn-primary {
-    background-color: var(--primary-color);
-    color: white;
+  background-color: var(--primary-color);
+  color: white;
 }
 
 .btn-primary:hover {
-    background-color: #3a7bc8;
+  background-color: #3a7bc8;
 }
 
 .btn-secondary {
-    background-color: var(--secondary-color);
-    color: white;
+  background-color: var(--secondary-color);
+  color: white;
 }
 
 .btn-secondary:hover {
-    background-color: #5a6268;
+  background-color: #5a6268;
 }
 
 /* Forms */
-input, select {
-    padding: 0.5rem;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    font-size: 1rem;
-    width: 100%;
-    margin-bottom: 0.5rem;
+input,
+select {
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 1rem;
+  width: 100%;
+  margin-bottom: 0.5rem;
 }
 
-input:focus, select:focus {
-    outline: none;
-    border-color: var(--primary-color);
+input:focus,
+select:focus {
+  outline: none;
+  border-color: var(--primary-color);
 }
 
 /* Index page */
 .index-page {
-    max-width: 1200px;
-    margin: 0 auto;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .index-page section {
-    background-color: var(--surface-color);
-    padding: 1.5rem;
-    border-radius: 8px;
-    margin-bottom: 1.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background-color: var(--surface-color);
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .index-page h2 {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .index-page h3 {
-    margin-bottom: 1rem;
-    color: var(--primary-color);
+  margin-bottom: 1rem;
+  color: var(--primary-color);
 }
 
 .workspace-list {
-    list-style: none;
-    margin-bottom: 1rem;
+  list-style: none;
+  margin-bottom: 1rem;
 }
 
 .workspace-list li {
-    padding: 0.5rem 0;
-    border-bottom: 1px solid var(--border-color);
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .workspace-list a {
-    color: var(--primary-color);
-    text-decoration: none;
+  color: var(--primary-color);
+  text-decoration: none;
 }
 
 .workspace-list a:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .plugin-category {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .plugin-category h4 {
-    color: var(--secondary-color);
-    margin-bottom: 0.5rem;
+  color: var(--secondary-color);
+  margin-bottom: 0.5rem;
 }
 
 .plugin-category ul {
-    list-style: none;
+  list-style: none;
 }
 
 .plugin-category li {
-    padding: 0.5rem 0;
+  padding: 0.5rem 0;
 }
 
 .plugin-category li p {
-    font-size: 0.9rem;
-    color: var(--secondary-color);
+  font-size: 0.9rem;
+  color: var(--secondary-color);
 }
 
 /* Placeholder text */
 .placeholder {
-    color: var(--secondary-color);
-    font-style: italic;
-    text-align: center;
-    padding: 2rem;
+  color: var(--secondary-color);
+  font-style: italic;
+  text-align: center;
+  padding: 2rem;
 }

--- a/graph-explorer/src/tangled_graph_explorer/static/css/workspace.css
+++ b/graph-explorer/src/tangled_graph_explorer/static/css/workspace.css
@@ -3,305 +3,304 @@
  */
 
 .workspace-page {
-    display: flex;
-    gap: 1rem;
-    height: calc(100vh - 140px);
+  display: flex;
+  gap: 1rem;
+  height: calc(100vh - 140px);
 }
 
 /* Control Panel (Left Sidebar) */
 .control-panel {
-    width: 280px;
-    flex-shrink: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .control-panel section {
-    background-color: var(--surface-color);
-    padding: 1rem;
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background-color: var(--surface-color);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .control-panel h3 {
-    font-size: 0.9rem;
-    color: var(--secondary-color);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--secondary-color);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.75rem;
 }
 
 /* Main Content Area */
 .main-content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
 }
 
 .top-row {
-    flex: 2;
-    display: flex;
-    gap: 1rem;
-    min-height: 0;
+  flex: 2;
+  display: flex;
+  gap: 1rem;
+  min-height: 0;
 }
 
 .bottom-row {
-    flex: 1;
-    display: flex;
-    gap: 1rem;
-    min-height: 200px;
+  flex: 1;
+  display: flex;
+  gap: 1rem;
+  min-height: 200px;
 }
 
 /* Tree View */
 .tree-view {
-    width: 300px;
-    flex-shrink: 0;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    display: flex;
-    flex-direction: column;
+  width: 300px;
+  flex-shrink: 0;
+  background-color: var(--surface-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
 }
 
 .tree-view h3 {
-    padding: 1rem;
-    border-bottom: 1px solid var(--border-color);
-    font-size: 0.9rem;
-    color: var(--secondary-color);
-    text-transform: uppercase;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.9rem;
+  color: var(--secondary-color);
+  text-transform: uppercase;
 }
 
 #tree-container {
-    flex: 1;
-    overflow: auto;
-    padding: 0.5rem;
+  flex: 1;
+  overflow: auto;
+  padding: 0.5rem;
 }
 
 /* Tree node styles */
 .tree-node {
-    padding: 0.25rem 0;
+  padding: 0.25rem 0;
 }
 
 .tree-node-header {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    padding: 0.25rem;
-    border-radius: 4px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 4px;
 }
 
 .tree-node-header:hover {
-    background-color: var(--background-color);
+  background-color: var(--background-color);
 }
 
 .tree-node-header.selected {
-    background-color: #e3f2fd;
+  background-color: #e3f2fd;
 }
 
 .tree-toggle {
-    width: 20px;
-    text-align: center;
-    font-family: monospace;
-    color: var(--secondary-color);
+  width: 20px;
+  text-align: center;
+  font-family: monospace;
+  color: var(--secondary-color);
 }
 
 .tree-label {
-    flex: 1;
+  flex: 1;
 }
 
 .tree-children {
-    margin-left: 20px;
-    display: none;
+  margin-left: 20px;
+  display: none;
 }
 
 .tree-children.expanded {
-    display: block;
+  display: block;
 }
 
 /* Main View */
 .main-view {
-    flex: 1;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
+  flex: 1;
+  background-color: var(--surface-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .main-view h3 {
-    padding: 1rem;
-    border-bottom: 1px solid var(--border-color);
-    font-size: 0.9rem;
-    color: var(--secondary-color);
-    text-transform: uppercase;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.9rem;
+  color: var(--secondary-color);
+  text-transform: uppercase;
 }
 
 #main-graph-container {
-    flex: 1;
-    position: relative;
-    overflow: hidden;
+  flex: 1;
+  position: relative;
+  overflow: hidden;
 }
 
 #main-graph-container svg {
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 /* Bird View */
 .bird-view {
-    width: 300px;
-    flex-shrink: 0;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    display: flex;
-    flex-direction: column;
+  width: 300px;
+  flex-shrink: 0;
+  background-color: var(--surface-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
 }
 
 .bird-view h3 {
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--border-color);
-    font-size: 0.9rem;
-    color: var(--secondary-color);
-    text-transform: uppercase;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.9rem;
+  color: var(--secondary-color);
+  text-transform: uppercase;
 }
 
 #bird-container {
-    flex: 1;
-    position: relative;
-    background-color: #f0f0f0;
+  flex: 1;
+  position: relative;
+  background-color: #f0f0f0;
 }
 
 #viewport-rect {
-    position: absolute;
-    border: 2px solid var(--primary-color);
-    background-color: rgba(74, 144, 217, 0.1);
-    pointer-events: none;
+  position: absolute;
+  border: 2px solid var(--primary-color);
+  background-color: rgba(74, 144, 217, 0.1);
+  pointer-events: none;
 }
 
 /* CLI Section */
 .cli-section {
-    flex: 1;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
+  flex: 1;
+  background-color: var(--surface-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .cli-section h3 {
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--border-color);
-    font-size: 0.9rem;
-    color: var(--secondary-color);
-    text-transform: uppercase;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.9rem;
+  color: var(--secondary-color);
+  text-transform: uppercase;
 }
 
 #cli-container {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    background-color: #1e1e1e;
-    color: #d4d4d4;
-    font-family: "Consolas", "Monaco", monospace;
-    font-size: 0.9rem;
-    border-radius: 0 0 8px 8px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background-color: #1e1e1e;
+  color: #d4d4d4;
+  font-family: "Consolas", "Monaco", monospace;
+  font-size: 0.9rem;
+  border-radius: 0 0 8px 8px;
 }
 
 #cli-output {
-    flex: 1;
-    padding: 0.5rem;
-    overflow-y: auto;
-    white-space: pre-wrap;
+  flex: 1;
+  padding: 0.5rem;
+  overflow-y: auto;
+  white-space: pre-wrap;
 }
 
 #cli-form {
-    display: flex;
-    align-items: center;
-    padding: 0.5rem;
-    border-top: 1px solid #333;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem;
+  border-top: 1px solid #333;
 }
 
 #cli-form .prompt {
-    color: #4ec9b0;
-    margin-right: 0.5rem;
+  color: #4ec9b0;
+  margin-right: 0.5rem;
 }
 
 #cli-input {
-    flex: 1;
-    background: transparent;
-    border: none;
-    color: #d4d4d4;
-    font-family: inherit;
-    font-size: inherit;
-    outline: none;
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #d4d4d4;
+  font-family: inherit;
+  font-size: inherit;
+  outline: none;
 }
 
 /* Graph visualization styles */
 .graph-container {
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 .graph-container .node circle {
-    fill: var(--primary-color);
-    stroke: #fff;
-    stroke-width: 2px;
-    cursor: pointer;
+  fill: var(--primary-color);
+  stroke: #fff;
+  stroke-width: 2px;
+  cursor: pointer;
 }
 
 .graph-container .node circle:hover {
-    fill: #3a7bc8;
+  fill: #3a7bc8;
 }
 
 .graph-container .node circle.selected {
-    stroke: var(--success-color);
-    stroke-width: 3px;
+  stroke: var(--success-color);
+  stroke-width: 3px;
 }
 
 .graph-container .node text {
-    font-size: 12px;
-    fill: var(--text-color);
-    pointer-events: none;
+  font-size: 12px;
+  fill: var(--text-color);
+  pointer-events: none;
 }
 
 .graph-container .edge line {
-    stroke: #999;
-    stroke-opacity: 0.6;
-    stroke-width: 1.5px;
+  stroke: #999;
+  stroke-opacity: 0.6;
+  stroke-width: 1.5px;
 }
 
 .graph-container .edge line.directed {
-    marker-end: url(#arrowhead);
+  marker-end: url(#arrowhead);
 }
 
 /* Block visualizer specific */
 .block-visualizer .node rect {
-    fill: var(--surface-color);
-    stroke: var(--primary-color);
-    stroke-width: 2px;
-    cursor: pointer;
+  fill: var(--surface-color);
+  stroke: var(--primary-color);
+  stroke-width: 2px;
+  cursor: pointer;
 }
 
 .block-visualizer .node rect:hover {
-    stroke-width: 3px;
+  stroke-width: 3px;
 }
 
 .block-visualizer .node .header {
-    fill: var(--primary-color);
+  fill: var(--primary-color);
 }
 
 .block-visualizer .node .header-text {
-    fill: white;
-    font-weight: bold;
+  fill: white;
 }
 
 .block-visualizer .node .attr-text {
-    font-size: 11px;
-    fill: var(--text-color);
+  font-size: 11px;
+  fill: var(--text-color);
 }

--- a/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
@@ -21,6 +21,7 @@ class GraphRenderer {
     this.onNodeSelect = null;
     this.onViewportChange = null;
     this.onSimulationTick = null;
+    this._hasZoomedToFit = false;
   }
 
   attach(svgId, data) {
@@ -41,13 +42,15 @@ class GraphRenderer {
       return;
     }
 
+    this._hasZoomedToFit = false;
     const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
 
+    // Place nodes in a circle initially, centered at origin
     data.nodes.forEach((node, i) => {
       const angle = (i / data.nodes.length) * 2 * Math.PI;
       const r = Math.min(w, h) * 0.3;
-      node.x = w / 2 + r * Math.cos(angle);
-      node.y = h / 2 + r * Math.sin(angle);
+      node.x = r * Math.cos(angle);
+      node.y = r * Math.sin(angle);
     });
 
     if (linkSelector) {
@@ -85,19 +88,20 @@ class GraphRenderer {
       .attr("marker-end", data.directed ? "url(#arrowhead-platform)" : null);
 
     const nodeBounds = this._measureNodeBounds(svgEl, nodeSelector, data.nodes);
+    this._lastNodeBounds = nodeBounds;
     const nodeRadius = this._detectNodeRadius(svgEl, nodeSelector);
 
     let currentTransform = d3.zoomIdentity;
 
+    // 150px screen-space buffer prevents pop-in at edges
     const getVisibleWorldRect = (t) => {
       const { k, x: tx, y: ty } = t;
-      const bufX = w / k;
-      const bufY = h / k;
+      const buf = 150 / k;
       return {
-        left: (0 - tx) / k - bufX,
-        right: (w - tx) / k + bufX,
-        top: (0 - ty) / k - bufY,
-        bottom: (h - ty) / k + bufY,
+        left: (0 - tx) / k - buf,
+        right: (w - tx) / k + buf,
+        top: (0 - ty) / k - buf,
+        bottom: (h - ty) / k + buf,
       };
     };
 
@@ -113,7 +117,7 @@ class GraphRenderer {
           node.x <= rect.right &&
           node.y >= rect.top &&
           node.y <= rect.bottom;
-        this.style.visibility = visible ? "" : "hidden";
+        this.style.visibility = visible ? "visible" : "hidden";
       });
 
       linkSelection.each(function (d) {
@@ -127,12 +131,13 @@ class GraphRenderer {
           d.target.x <= rect.right &&
           d.target.y >= rect.top &&
           d.target.y <= rect.bottom;
-        this.style.visibility = srcVisible || tgtVisible ? "" : "hidden";
+        this.style.visibility = srcVisible || tgtVisible ? "visible" : "hidden";
       });
     };
 
     const nodeDomElements = this.mainGroup.selectAll(nodeSelector);
 
+    // Hide everything initially; culling will reveal what's in view
     nodeDomElements.each(function () {
       this.style.visibility = "hidden";
     });
@@ -150,24 +155,31 @@ class GraphRenderer {
           })
           .on("start", (event) => {
             if (!event.subject) return;
-            if (!event.active) this.simulation.alphaTarget(0.3).restart();
+            if (!event.active) this.simulation.alphaTarget(0.05).restart();
             event.subject.fx = event.subject.x;
             event.subject.fy = event.subject.y;
           })
           .on("drag", (event) => {
             if (!event.subject) return;
+            // Clamp to current visible world rect so nodes can't be dragged off screen
             const bound = nodeBounds.get(event.subject.id) || {
               hw: nodeRadius,
               hh: nodeRadius,
             };
-            const { minX, maxX, minY, maxY } = GraphRenderer._worldBounds(
-              w,
-              h,
-              currentTransform,
-              bound,
+            const { k, x: tx, y: ty } = currentTransform;
+            const pad = 10;
+            const worldLeft = (0 - tx) / k + (bound.hw + pad) / k;
+            const worldRight = (w - tx) / k - (bound.hw + pad) / k;
+            const worldTop = (0 - ty) / k + (bound.hh + pad) / k;
+            const worldBottom = (h - ty) / k - (bound.hh + pad) / k;
+            event.subject.fx = Math.max(
+              worldLeft,
+              Math.min(worldRight, event.x),
             );
-            event.subject.fx = Math.max(minX, Math.min(maxX, event.x));
-            event.subject.fy = Math.max(minY, Math.min(maxY, event.y));
+            event.subject.fy = Math.max(
+              worldTop,
+              Math.min(worldBottom, event.y),
+            );
           })
           .on("end", (event) => {
             if (!event.subject) return;
@@ -191,7 +203,7 @@ class GraphRenderer {
 
     this.zoom = d3
       .zoom()
-      .scaleExtent([0.1, 4])
+      .scaleExtent([0.05, 4])
       .on("zoom", (event) => {
         currentTransform = event.transform;
         this.mainGroup.attr("transform", currentTransform);
@@ -203,41 +215,27 @@ class GraphRenderer {
     this.simulation = d3
       .forceSimulation(data.nodes)
       .alphaDecay(0.04)
-      .velocityDecay(0.55)
+      .velocityDecay(0.85)
       .force(
         "link",
         d3
           .forceLink(data.edges)
           .id((d) => d.id)
-          .distance(250)
-          .strength(0.3),
+          .distance(220)
+          .strength(0.6),
       )
-      .force("charge", d3.forceManyBody().strength(-400).distanceMax(600))
+      .force("charge", d3.forceManyBody().strength(-200).distanceMax(400))
       .force(
         "collide",
         d3
           .forceCollide()
-          .radius(nodeRadius + 20)
-          .strength(0.8)
-          .iterations(3),
+          .radius(nodeRadius + 15)
+          .strength(0.7)
+          .iterations(2),
       )
-      .force("center", d3.forceCenter(w / 2, h / 2).strength(0.05))
+      .force("x", d3.forceX(0).strength(0.03))
+      .force("y", d3.forceY(0).strength(0.03))
       .on("tick", () => {
-        data.nodes.forEach((node) => {
-          const bound = nodeBounds.get(node.id) || {
-            hw: nodeRadius,
-            hh: nodeRadius,
-          };
-          const { minX, maxX, minY, maxY } = GraphRenderer._worldBounds(
-            w,
-            h,
-            currentTransform,
-            bound,
-          );
-          node.x = Math.max(minX, Math.min(maxX, node.x));
-          node.y = Math.max(minY, Math.min(maxY, node.y));
-        });
-
         linkSelection.each(function (d) {
           const sx = d.source.x,
             sy = d.source.y;
@@ -277,28 +275,79 @@ class GraphRenderer {
         if (this.onSimulationTick) this.onSimulationTick(data);
       })
       .on("end", () => {
+        if (!this._hasZoomedToFit) {
+          this._hasZoomedToFit = true;
+          this._zoomToFit(w, h, data.nodes);
+        }
         if (this.onSimulationTick) this.onSimulationTick(data);
       });
+
+    const initTransform = d3.zoomIdentity.translate(w / 2, h / 2);
+    this.svg.call(this.zoom.transform, initTransform);
+
+    setTimeout(() => applyCulling(currentTransform), 100);
   }
 
-  static _worldBounds(svgW, svgH, t, bound) {
-    const padding = 10;
-    const { k, x: tx, y: ty } = t;
+  // Zoom and pan so all nodes fit in the viewport
+  _zoomToFit(w, h, nodes) {
+    if (!nodes.length) return;
 
-    const worldLeft = (0 - tx) / k;
-    const worldRight = (svgW - tx) / k;
-    const worldTop = (0 - ty) / k;
-    const worldBottom = (svgH - ty) / k;
+    const svgEl = this.svg.node();
+    let minX = Infinity,
+      maxX = -Infinity;
+    let minY = Infinity,
+      maxY = -Infinity;
 
-    const hwWorld = (bound.hw + padding) / k;
-    const hhWorld = (bound.hh + padding) / k;
+    nodes.forEach((n) => {
+      if (!isFinite(n.x) || !isFinite(n.y)) return;
 
-    return {
-      minX: worldLeft + hwWorld,
-      maxX: worldRight - hwWorld,
-      minY: worldTop + hhWorld,
-      maxY: worldBottom - hhWorld,
-    };
+      let hw = 100,
+        hh = 40;
+      const el = svgEl.querySelector(`[id="${n.id}"]`);
+      if (el) {
+        const rect = el.querySelector("rect");
+        if (rect) {
+          const rw = parseFloat(rect.getAttribute("width") || 0);
+          const rh = parseFloat(rect.getAttribute("height") || 0);
+          if (rw > 0 && rh > 0) {
+            hw = rw / 2;
+            hh = rh / 2;
+          }
+        }
+      }
+
+      minX = Math.min(minX, n.x - hw);
+      maxX = Math.max(maxX, n.x + hw);
+      minY = Math.min(minY, n.y - hh);
+      maxY = Math.max(maxY, n.y + hh);
+    });
+
+    const padding = 80;
+    const graphW = maxX - minX + padding * 2;
+    const graphH = maxY - minY + padding * 2;
+
+    const k = Math.min(w / graphW, h / graphH, 1);
+    const centerX = (minX + maxX) / 2;
+    const centerY = (minY + maxY) / 2;
+    const tx = w / 2 - k * centerX;
+    const ty = h / 2 - k * centerY;
+
+    this.svg
+      .transition()
+      .duration(600)
+      .call(this.zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(k));
+  }
+
+  static _boxEdgePoint(fx, fy, tx, ty, box) {
+    if (!box) return { x: fx, y: fy };
+    const { hw, hh } = box;
+    const dx = tx - fx,
+      dy = ty - fy;
+    if (dx === 0 && dy === 0) return { x: fx, y: fy };
+    const scaleX = dx !== 0 ? hw / Math.abs(dx) : Infinity;
+    const scaleY = dy !== 0 ? hh / Math.abs(dy) : Infinity;
+    const scale = Math.min(scaleX, scaleY);
+    return { x: fx + dx * scale, y: fy + dy * scale };
   }
 
   _measureNodeBounds(svgEl, nodeSelector, nodes) {
@@ -315,7 +364,6 @@ class GraphRenderer {
             return;
           }
         }
-        // Circle fallback
         const circle = el.querySelector("circle");
         if (circle) {
           const r = parseFloat(circle.getAttribute("r") || 20);
@@ -327,18 +375,6 @@ class GraphRenderer {
       bounds.set(node.id, { hw: fallback, hh: fallback });
     });
     return bounds;
-  }
-
-  static _boxEdgePoint(fx, fy, tx, ty, box) {
-    if (!box) return { x: fx, y: fy };
-    const { hw, hh } = box;
-    const dx = tx - fx,
-      dy = ty - fy;
-    if (dx === 0 && dy === 0) return { x: fx, y: fy };
-    const scaleX = dx !== 0 ? hw / Math.abs(dx) : Infinity;
-    const scaleY = dy !== 0 ? hh / Math.abs(dy) : Infinity;
-    const scale = Math.min(scaleX, scaleY);
-    return { x: fx + dx * scale, y: fy + dy * scale };
   }
 
   _detectNodeRadius(svgEl, nodeSelector) {
@@ -406,6 +442,7 @@ class GraphRenderer {
     console.log("Node:", node);
   }
   _hideTooltip() {}
+
   getTransform() {
     return d3.zoomTransform(this.svg.node());
   }

--- a/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
@@ -18,212 +18,11 @@ class GraphRenderer {
     this.zoom = null;
     this.selectedNode = null;
 
-    // Callbacks for view synchronization
     this.onNodeSelect = null;
     this.onViewportChange = null;
+    this.onSimulationTick = null;
   }
 
-  /**
-   * Initialize the SVG and D3 components
-   */
-  init() {
-    if (!this.container) return;
-
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
-
-    // Clear existing content
-    this.container.innerHTML = "";
-
-    // Create SVG
-    this.svg = d3
-      .select(this.container)
-      .append("svg")
-      .attr("width", width)
-      .attr("height", height);
-
-    // Add arrow marker for directed edges
-    this.svg
-      .append("defs")
-      .append("marker")
-      .attr("id", "arrowhead")
-      .attr("viewBox", "-0 -5 10 10")
-      .attr("refX", 20)
-      .attr("refY", 0)
-      .attr("orient", "auto")
-      .attr("markerWidth", 6)
-      .attr("markerHeight", 6)
-      .append("path")
-      .attr("d", "M 0,-5 L 10,0 L 0,5")
-      .attr("fill", "#999");
-
-    // Create main group for zoom/pan
-    this.mainGroup = this.svg.append("g");
-
-    // Setup zoom behavior
-    this.zoom = d3
-      .zoom()
-      .scaleExtent([0.1, 4])
-      .on("zoom", (event) => {
-        this.mainGroup.attr("transform", event.transform);
-        if (this.onViewportChange) {
-          this.onViewportChange(event.transform);
-        }
-      });
-
-    this.svg.call(this.zoom);
-  }
-
-  /**
-   * Render graph data
-   * @param {Object} data - Graph data with nodes and edges arrays
-   */
-  render(data) {
-    if (!this.svg) this.init();
-    if (!data || !data.nodes) return;
-
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
-
-    // Clear previous graph
-    this.mainGroup.selectAll("*").remove();
-
-    // Create simulation
-    this.simulation = d3
-      .forceSimulation(data.nodes)
-      .force(
-        "link",
-        d3
-          .forceLink(data.edges)
-          .id((d) => d.id)
-          .distance(100),
-      )
-      .force("charge", d3.forceManyBody().strength(-300))
-      .force("center", d3.forceCenter(width / 2, height / 2));
-
-    // Draw edges
-    const edges = this.mainGroup
-      .append("g")
-      .attr("class", "edges")
-      .selectAll("line")
-      .data(data.edges)
-      .enter()
-      .append("line")
-      .attr("class", (d) => `edge ${data.directed ? "directed" : ""}`)
-      .attr("marker-end", (d) => (data.directed ? "url(#arrowhead)" : null));
-
-    // Draw nodes
-    const nodes = this.mainGroup
-      .append("g")
-      .attr("class", "nodes")
-      .selectAll("g")
-      .data(data.nodes)
-      .enter()
-      .append("g")
-      .attr("class", "node")
-      .call(this._drag());
-
-    // Node circles
-    nodes
-      .append("circle")
-      .attr("r", 15)
-      .on("click", (event, d) => this._selectNode(d))
-      .on("mouseover", (event, d) => this._showTooltip(event, d))
-      .on("mouseout", () => this._hideTooltip());
-
-    // Node labels
-    nodes
-      .append("text")
-      .attr("dy", 4)
-      .attr("text-anchor", "middle")
-      .text((d) => d.label || d.id);
-
-    // Update positions on simulation tick
-    this.simulation.on("tick", () => {
-      edges
-        .attr("x1", (d) => d.source.x)
-        .attr("y1", (d) => d.source.y)
-        .attr("x2", (d) => d.target.x)
-        .attr("y2", (d) => d.target.y);
-
-      nodes.attr("transform", (d) => `translate(${d.x},${d.y})`);
-    });
-  }
-
-  /**
-   * Create drag behavior
-   */
-  _drag() {
-    return d3
-      .drag()
-      .on("start", (event, d) => {
-        if (!event.active) this.simulation.alphaTarget(0.3).restart();
-        d.fx = d.x;
-        d.fy = d.y;
-      })
-      .on("drag", (event, d) => {
-        d.fx = event.x;
-        d.fy = event.y;
-      })
-      .on("end", (event, d) => {
-        if (!event.active) this.simulation.alphaTarget(0);
-        d.fx = null;
-        d.fy = null;
-      });
-  }
-
-  /**
-   * Handle node selection
-   */
-  _selectNode(node) {
-    // Update visual selection
-    this.mainGroup
-      .selectAll(".node circle")
-      .classed("selected", (d) => d.id === node.id);
-
-    this.selectedNode = node;
-
-    if (this.onNodeSelect) {
-      this.onNodeSelect(node);
-    }
-  }
-
-  /**
-   * Select node by ID (for cross-view synchronization)
-   */
-  selectNodeById(nodeId) {
-    const node = this.simulation?.nodes().find((n) => n.id === nodeId);
-    if (node) {
-      this._selectNode(node);
-    }
-  }
-
-  /**
-   * Show tooltip on hover
-   */
-  _showTooltip(event, node) {
-    // TODO: Implement tooltip UI
-    console.log("Node:", node);
-  }
-
-  /**
-   * Hide tooltip
-   */
-  _hideTooltip() {
-    // TODO: Implement tooltip UI
-  }
-
-  /**
-   * Get current viewport transform
-   */
-  getTransform() {
-    return d3.zoomTransform(this.svg.node());
-  }
-
-  /**
-   * Attach to existing SVG rendered by a visualizer template.
-   * Adds simulation, drag, zoom without clearing existing elements.
-   */
   attach(svgId, data) {
     const svgEl = document.getElementById(svgId);
     if (!svgEl) return;
@@ -234,89 +33,381 @@ class GraphRenderer {
     this.svg = d3.select(svgEl).attr("width", w).attr("height", h);
     this.mainGroup = this.svg.select("g");
 
+    const nodeSelector = this._resolveNodeSelector(svgEl, data.nodes.length);
+    const linkSelector = this._resolveLinkSelector(svgEl);
+
+    if (!nodeSelector) {
+      console.warn("GraphRenderer: could not find node elements in SVG.");
+      return;
+    }
+
+    const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+
     data.nodes.forEach((node, i) => {
-      if (node.x == null || node.x === 0) {
-        const angle = (i / data.nodes.length) * 2 * Math.PI;
-        const r = Math.min(w, h) * 0.3;
-        node.x = w / 2 + r * Math.cos(angle);
-        node.y = h / 2 + r * Math.sin(angle);
-      }
+      const angle = (i / data.nodes.length) * 2 * Math.PI;
+      const r = Math.min(w, h) * 0.3;
+      node.x = w / 2 + r * Math.cos(angle);
+      node.y = h / 2 + r * Math.sin(angle);
     });
 
-    this.mainGroup.selectAll(".link").remove();
-    const linkGroup = this.mainGroup.insert("g", ":first-child");
+    if (linkSelector) {
+      this.mainGroup.selectAll(linkSelector).remove();
+    }
+
+    // Arrowhead marker
+    let defs = this.svg.select("defs");
+    if (defs.empty()) defs = this.svg.insert("defs", ":first-child");
+    defs.selectAll("#arrowhead-platform").remove();
+    defs
+      .append("marker")
+      .attr("id", "arrowhead-platform")
+      .attr("viewBox", "0 -6 12 12")
+      .attr("refX", 12)
+      .attr("refY", 0)
+      .attr("markerWidth", 10)
+      .attr("markerHeight", 10)
+      .attr("orient", "auto")
+      .append("path")
+      .attr("d", "M0,-6 L12,0 L0,6 Z")
+      .attr("fill", "#1a699e");
+
+    const linkGroup = this.mainGroup
+      .insert("g", ":first-child")
+      .attr("class", "platform-links");
+
     const linkSelection = linkGroup
-      .selectAll(".link")
+      .selectAll("line")
       .data(data.edges)
       .enter()
       .append("line")
-      .attr("class", "link")
       .style("stroke", "#1a699e82")
       .style("stroke-width", "1.5px")
-      .attr("marker-end", (d) => (data.directed ? "url(#arrowhead)" : null));
+      .attr("marker-end", data.directed ? "url(#arrowhead-platform)" : null);
 
-    const nodeSelection = this.mainGroup
-      .selectAll(".node")
-      .data(data.nodes, (d) => d.id)
-      .call(this._drag())
-      .on("click", (event, d) => this._selectNode(d))
-      .on("mouseover", (event, d) => this._showTooltip(event, d))
-      .on("mouseout", () => this._hideTooltip());
+    const nodeBounds = this._measureNodeBounds(svgEl, nodeSelector, data.nodes);
+    const nodeRadius = this._detectNodeRadius(svgEl, nodeSelector);
+
+    let currentTransform = d3.zoomIdentity;
+
+    const getVisibleWorldRect = (t) => {
+      const { k, x: tx, y: ty } = t;
+      const bufX = w / k;
+      const bufY = h / k;
+      return {
+        left: (0 - tx) / k - bufX,
+        right: (w - tx) / k + bufX,
+        top: (0 - ty) / k - bufY,
+        bottom: (h - ty) / k + bufY,
+      };
+    };
+
+    const applyCulling = (t) => {
+      const rect = getVisibleWorldRect(t);
+
+      nodeDomElements.each(function () {
+        const id = d3.select(this).attr("id");
+        const node = nodeById.get(id);
+        if (!node) return;
+        const visible =
+          node.x >= rect.left &&
+          node.x <= rect.right &&
+          node.y >= rect.top &&
+          node.y <= rect.bottom;
+        this.style.visibility = visible ? "" : "hidden";
+      });
+
+      linkSelection.each(function (d) {
+        const srcVisible =
+          d.source.x >= rect.left &&
+          d.source.x <= rect.right &&
+          d.source.y >= rect.top &&
+          d.source.y <= rect.bottom;
+        const tgtVisible =
+          d.target.x >= rect.left &&
+          d.target.x <= rect.right &&
+          d.target.y >= rect.top &&
+          d.target.y <= rect.bottom;
+        this.style.visibility = srcVisible || tgtVisible ? "" : "hidden";
+      });
+    };
+
+    const nodeDomElements = this.mainGroup.selectAll(nodeSelector);
+
+    nodeDomElements.each(function () {
+      this.style.visibility = "hidden";
+    });
+    linkSelection.each(function () {
+      this.style.visibility = "hidden";
+    });
+
+    nodeDomElements
+      .call(
+        d3
+          .drag()
+          .subject((event) => {
+            const g = event.sourceEvent.target.closest("g[id]");
+            return g ? nodeById.get(g.id) || null : null;
+          })
+          .on("start", (event) => {
+            if (!event.subject) return;
+            if (!event.active) this.simulation.alphaTarget(0.3).restart();
+            event.subject.fx = event.subject.x;
+            event.subject.fy = event.subject.y;
+          })
+          .on("drag", (event) => {
+            if (!event.subject) return;
+            const bound = nodeBounds.get(event.subject.id) || {
+              hw: nodeRadius,
+              hh: nodeRadius,
+            };
+            const { minX, maxX, minY, maxY } = GraphRenderer._worldBounds(
+              w,
+              h,
+              currentTransform,
+              bound,
+            );
+            event.subject.fx = Math.max(minX, Math.min(maxX, event.x));
+            event.subject.fy = Math.max(minY, Math.min(maxY, event.y));
+          })
+          .on("end", (event) => {
+            if (!event.subject) return;
+            if (!event.active) this.simulation.alphaTarget(0);
+            event.subject.fx = null;
+            event.subject.fy = null;
+          }),
+      )
+      .on("click.platform", (event) => {
+        const el = event.currentTarget;
+        const id = d3.select(el).attr("id");
+        const node = nodeById.get(id);
+        if (node) this._selectNode(node);
+      })
+      .on("mouseover.platform", (event) => {
+        const id = d3.select(event.currentTarget).attr("id");
+        const node = nodeById.get(id);
+        if (node) this._showTooltip(event, node);
+      })
+      .on("mouseout.platform", () => this._hideTooltip());
 
     this.zoom = d3
       .zoom()
       .scaleExtent([0.1, 4])
       .on("zoom", (event) => {
-        this.mainGroup.attr("transform", event.transform);
-        if (this.onViewportChange) this.onViewportChange(event.transform);
+        currentTransform = event.transform;
+        this.mainGroup.attr("transform", currentTransform);
+        applyCulling(currentTransform);
+        if (this.onViewportChange) this.onViewportChange(currentTransform);
       });
     this.svg.call(this.zoom);
 
     this.simulation = d3
       .forceSimulation(data.nodes)
+      .alphaDecay(0.04)
+      .velocityDecay(0.55)
       .force(
         "link",
         d3
           .forceLink(data.edges)
           .id((d) => d.id)
-          .distance(150),
+          .distance(250)
+          .strength(0.3),
       )
-      .force("charge", d3.forceManyBody().strength(-500))
-      .force("center", d3.forceCenter(w / 2, h / 2))
-      .on("tick", () => {
-        linkSelection
-          .attr("x1", (d) => d.source.x)
-          .attr("y1", (d) => d.source.y)
-          .attr("x2", (d) => d.target.x)
-          .attr("y2", (d) => d.target.y);
-
-        nodeSelection.attr("transform", (d) => `translate(${d.x},${d.y})`);
-      });
-    this.simulation = d3
-      .forceSimulation(data.nodes)
+      .force("charge", d3.forceManyBody().strength(-400).distanceMax(600))
       .force(
-        "link",
+        "collide",
         d3
-          .forceLink(data.edges)
-          .id((d) => d.id)
-          .distance(150),
+          .forceCollide()
+          .radius(nodeRadius + 20)
+          .strength(0.8)
+          .iterations(3),
       )
-      .force("charge", d3.forceManyBody().strength(-500))
-      .force("center", d3.forceCenter(w / 2, h / 2))
+      .force("center", d3.forceCenter(w / 2, h / 2).strength(0.05))
       .on("tick", () => {
-        linkSelection
-          .attr("x1", (d) => d.source.x)
-          .attr("y1", (d) => d.source.y)
-          .attr("x2", (d) => d.target.x)
-          .attr("y2", (d) => d.target.y);
+        data.nodes.forEach((node) => {
+          const bound = nodeBounds.get(node.id) || {
+            hw: nodeRadius,
+            hh: nodeRadius,
+          };
+          const { minX, maxX, minY, maxY } = GraphRenderer._worldBounds(
+            w,
+            h,
+            currentTransform,
+            bound,
+          );
+          node.x = Math.max(minX, Math.min(maxX, node.x));
+          node.y = Math.max(minY, Math.min(maxY, node.y));
+        });
 
-        nodeSelection.attr("transform", (d) => `translate(${d.x},${d.y})`);
+        linkSelection.each(function (d) {
+          const sx = d.source.x,
+            sy = d.source.y;
+          const tx = d.target.x,
+            ty = d.target.y;
+          const p1 = GraphRenderer._boxEdgePoint(
+            sx,
+            sy,
+            tx,
+            ty,
+            nodeBounds.get(d.source.id),
+          );
+          const p2 = GraphRenderer._boxEdgePoint(
+            tx,
+            ty,
+            sx,
+            sy,
+            nodeBounds.get(d.target.id),
+          );
+          d3.select(this)
+            .attr("x1", p1.x)
+            .attr("y1", p1.y)
+            .attr("x2", p2.x)
+            .attr("y2", p2.y);
+        });
+
+        nodeDomElements.each(function () {
+          const id = d3.select(this).attr("id");
+          const node = nodeById.get(id);
+          if (node && isFinite(node.x) && isFinite(node.y)) {
+            d3.select(this).attr("transform", `translate(${node.x},${node.y})`);
+          }
+        });
+
+        applyCulling(currentTransform);
 
         if (this.onSimulationTick) this.onSimulationTick(data);
       })
       .on("end", () => {
         if (this.onSimulationTick) this.onSimulationTick(data);
       });
+  }
+
+  static _worldBounds(svgW, svgH, t, bound) {
+    const padding = 10;
+    const { k, x: tx, y: ty } = t;
+
+    const worldLeft = (0 - tx) / k;
+    const worldRight = (svgW - tx) / k;
+    const worldTop = (0 - ty) / k;
+    const worldBottom = (svgH - ty) / k;
+
+    const hwWorld = (bound.hw + padding) / k;
+    const hhWorld = (bound.hh + padding) / k;
+
+    return {
+      minX: worldLeft + hwWorld,
+      maxX: worldRight - hwWorld,
+      minY: worldTop + hhWorld,
+      maxY: worldBottom - hhWorld,
+    };
+  }
+
+  _measureNodeBounds(svgEl, nodeSelector, nodes) {
+    const bounds = new Map();
+    nodes.forEach((node) => {
+      const el = svgEl.querySelector(`${nodeSelector}[id="${node.id}"]`);
+      if (el) {
+        const rect = el.querySelector("rect");
+        if (rect) {
+          const w = parseFloat(rect.getAttribute("width") || 0);
+          const h = parseFloat(rect.getAttribute("height") || 0);
+          if (w > 0 && h > 0) {
+            bounds.set(node.id, { hw: w / 2, hh: h / 2 });
+            return;
+          }
+        }
+        // Circle fallback
+        const circle = el.querySelector("circle");
+        if (circle) {
+          const r = parseFloat(circle.getAttribute("r") || 20);
+          bounds.set(node.id, { hw: r, hh: r });
+          return;
+        }
+      }
+      const fallback = this._detectNodeRadius(svgEl, nodeSelector);
+      bounds.set(node.id, { hw: fallback, hh: fallback });
+    });
+    return bounds;
+  }
+
+  static _boxEdgePoint(fx, fy, tx, ty, box) {
+    if (!box) return { x: fx, y: fy };
+    const { hw, hh } = box;
+    const dx = tx - fx,
+      dy = ty - fy;
+    if (dx === 0 && dy === 0) return { x: fx, y: fy };
+    const scaleX = dx !== 0 ? hw / Math.abs(dx) : Infinity;
+    const scaleY = dy !== 0 ? hh / Math.abs(dy) : Infinity;
+    const scale = Math.min(scaleX, scaleY);
+    return { x: fx + dx * scale, y: fy + dy * scale };
+  }
+
+  _detectNodeRadius(svgEl, nodeSelector) {
+    if (svgEl.dataset.nodeRadius) return parseFloat(svgEl.dataset.nodeRadius);
+    const firstNode = svgEl.querySelector(nodeSelector);
+    if (firstNode) {
+      const circle = firstNode.querySelector("circle");
+      if (circle) return parseFloat(circle.getAttribute("r") || 20);
+      const rect = firstNode.querySelector("rect");
+      if (rect) {
+        const rw = parseFloat(rect.getAttribute("width") || 100);
+        const rh = parseFloat(rect.getAttribute("height") || 50);
+        return Math.sqrt((rw / 2) ** 2 + (rh / 2) ** 2);
+      }
+    }
+    return 40;
+  }
+
+  _resolveNodeSelector(svgEl, nodeCount) {
+    if (svgEl.dataset.nodeSelector) return svgEl.dataset.nodeSelector;
+    const mainG = svgEl.querySelector("g");
+    if (!mainG) return null;
+    const classCounts = {};
+    mainG.querySelectorAll(":scope > g[class]").forEach((el) => {
+      el.classList.forEach((cls) => {
+        classCounts[cls] = (classCounts[cls] || 0) + 1;
+      });
+    });
+    let bestClass = null,
+      bestDiff = Infinity;
+    for (const [cls, count] of Object.entries(classCounts)) {
+      const diff = Math.abs(count - nodeCount);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        bestClass = cls;
+      }
+    }
+    return bestClass ? `.${bestClass}` : null;
+  }
+
+  _resolveLinkSelector(svgEl) {
+    if (svgEl.dataset.linkSelector) return svgEl.dataset.linkSelector;
+    const mainG = svgEl.querySelector("g");
+    if (!mainG) return null;
+    if (mainG.querySelectorAll(":scope > line").length > 0)
+      return ":scope > line";
+    if (mainG.querySelectorAll(":scope > path").length > 0)
+      return ":scope > path";
+    if (mainG.querySelectorAll(":scope > g > line").length > 0) return "line";
+    if (mainG.querySelectorAll(":scope > g > path").length > 0) return "path";
+    return null;
+  }
+
+  _selectNode(node) {
+    this.selectedNode = node;
+    if (this.onNodeSelect) this.onNodeSelect(node);
+  }
+
+  selectNodeById(nodeId) {
+    const node = this.simulation?.nodes().find((n) => n.id === nodeId);
+    if (node) this._selectNode(node);
+  }
+
+  _showTooltip(event, node) {
+    console.log("Node:", node);
+  }
+  _hideTooltip() {}
+  getTransform() {
+    return d3.zoomTransform(this.svg.node());
   }
 }
 

--- a/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
@@ -155,7 +155,7 @@ class GraphRenderer {
           })
           .on("start", (event) => {
             if (!event.subject) return;
-            if (!event.active) this.simulation.alphaTarget(0.05).restart();
+            if (!event.active) this.simulation.alphaTarget(0.35).restart();
             event.subject.fx = event.subject.x;
             event.subject.fy = event.subject.y;
           })

--- a/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
@@ -3,17 +3,13 @@
  *
  * Coordinates all views (Main, Tree, Bird) and handles user interactions.
  */
-
 class WorkspaceController {
   constructor() {
     this.workspaceId =
       document.querySelector(".workspace-page")?.dataset.workspaceId;
-
-    // Initialize view components
     this.graphRenderer = new GraphRenderer("main-graph-container");
     this.treeView = new TreeView("tree-container");
     this.birdView = new BirdView("bird-container");
-
     this.graphData = null;
 
     this._setupEventHandlers();
@@ -21,97 +17,58 @@ class WorkspaceController {
     this._loadDataSources();
   }
 
-  /**
-   * Setup form and button event handlers
-   */
   _setupEventHandlers() {
-    // Load data form
-    const loadForm = document.getElementById("load-data-form");
-    loadForm?.addEventListener("submit", (e) => {
+    document
+      .getElementById("load-data-form")
+      ?.addEventListener("submit", (e) => {
+        e.preventDefault();
+        this._handleLoadData();
+      });
+    document
+      .getElementById("data-source-select")
+      ?.addEventListener("change", (e) => {
+        this._updatePluginParams(e.target.value);
+      });
+    document
+      .getElementById("visualizer-select")
+      ?.addEventListener("change", () => {
+        this._refreshVisualization();
+      });
+    document.getElementById("search-form")?.addEventListener("submit", (e) => {
       e.preventDefault();
-      this._handleLoadData();
+      this._handleSearch(document.getElementById("search-input").value);
     });
-
-    // Data source selection
-    const dataSourceSelect = document.getElementById("data-source-select");
-    dataSourceSelect?.addEventListener("change", (e) => {
-      this._updatePluginParams(e.target.value);
-    });
-
-    // Visualizer selection
-    const visualizerSelect = document.getElementById("visualizer-select");
-    visualizerSelect?.addEventListener("change", () => {
-      this._refreshVisualization();
-    });
-
-    // Search form
-    const searchForm = document.getElementById("search-form");
-    searchForm?.addEventListener("submit", (e) => {
+    document.getElementById("filter-form")?.addEventListener("submit", (e) => {
       e.preventDefault();
-      const query = document.getElementById("search-input").value;
-      this._handleSearch(query);
+      this._handleFilter(document.getElementById("filter-input").value);
     });
-
-    // Filter form
-    const filterForm = document.getElementById("filter-form");
-    filterForm?.addEventListener("submit", (e) => {
+    document
+      .getElementById("reset-btn")
+      ?.addEventListener("click", () => this._handleReset());
+    document.getElementById("cli-form")?.addEventListener("submit", (e) => {
       e.preventDefault();
-      const query = document.getElementById("filter-input").value;
-      this._handleFilter(query);
-    });
-
-    // Reset button
-    const resetBtn = document.getElementById("reset-btn");
-    resetBtn?.addEventListener("click", () => {
-      this._handleReset();
-    });
-
-    // CLI form
-    const cliForm = document.getElementById("cli-form");
-    cliForm?.addEventListener("submit", (e) => {
-      e.preventDefault();
-      const command = document.getElementById("cli-input").value;
-      this._handleCliCommand(command);
-      document.getElementById("cli-input").value = "";
+      const input = document.getElementById("cli-input");
+      this._handleCliCommand(input.value);
+      input.value = "";
     });
   }
 
-  /**
-   * Setup cross-view synchronization
-   */
   _setupViewSynchronization() {
-    // Sync node selection across views
-    this.graphRenderer.onNodeSelect = (node) => {
+    this.graphRenderer.onNodeSelect = (node) =>
       this.treeView.selectNodeById(node.id);
-      // Bird view doesn't need selection sync
-    };
-
-    this.treeView.onNodeSelect = (node) => {
+    this.treeView.onNodeSelect = (node) =>
       this.graphRenderer.selectNodeById(node.id);
-    };
-
-    // Sync viewport changes to bird view
     this.graphRenderer.onViewportChange = (transform) => {
-      const container = document.getElementById("main-graph-container");
-      this.birdView.updateViewport(
-        transform,
-        container.clientWidth,
-        container.clientHeight,
-      );
+      const c = document.getElementById("main-graph-container");
+      this.birdView.updateViewport(transform, c.clientWidth, c.clientHeight);
     };
-    this.graphRenderer.onSimulationTick = (data) => {
-      this.birdView.render(data);
-    };
+    this.graphRenderer.onSimulationTick = (data) => this.birdView.render(data);
   }
 
-  /**
-   * Load available data sources and populate dropdown
-   */
   async _loadDataSources() {
     try {
       const sources = await api.get("/api/plugins/datasources");
       const select = document.getElementById("data-source-select");
-
       sources.forEach((source) => {
         const option = document.createElement("option");
         option.value = source.id;
@@ -119,92 +76,67 @@ class WorkspaceController {
         option.dataset.params = JSON.stringify(source.parameters);
         select.appendChild(option);
       });
-    } catch (error) {
-      console.error("Failed to load data sources:", error);
+    } catch (e) {
+      console.error("Failed to load data sources:", e);
     }
   }
 
-  /**
-   * Update parameter inputs based on selected plugin
-   */
   _updatePluginParams(pluginId) {
-    const paramsContainer = document.getElementById("plugin-params");
-    paramsContainer.innerHTML = "";
-
+    const container = document.getElementById("plugin-params");
+    container.innerHTML = "";
     if (!pluginId) return;
-
-    const option = document.querySelector(`option[value="${pluginId}"]`);
-    const params = JSON.parse(option.dataset.params || "[]");
-
+    const params = JSON.parse(
+      document.querySelector(`option[value="${pluginId}"]`)?.dataset.params ||
+        "[]",
+    );
     params.forEach((param) => {
       const div = document.createElement("div");
       div.className = "param-input";
-
       const label = document.createElement("label");
       label.textContent = param.name + (param.required ? " *" : "");
       label.title = param.description;
-
       const input = document.createElement("input");
       input.type = "text";
       input.name = param.name;
       input.placeholder = param.description;
       if (param.default) input.value = param.default;
       if (param.required) input.required = true;
-
       div.appendChild(label);
       div.appendChild(input);
-      paramsContainer.appendChild(div);
+      container.appendChild(div);
     });
   }
 
-  /**
-   * Handle load data form submission
-   */
   async _handleLoadData() {
-    const select = document.getElementById("data-source-select");
-    const pluginId = select.value;
-
+    const pluginId = document.getElementById("data-source-select").value;
     if (!pluginId) {
       showNotification("Please select a data source", "error");
       return;
     }
-
-    // Collect parameters
     const params = {};
-    document.querySelectorAll("#plugin-params input").forEach((input) => {
-      if (input.value) {
-        params[input.name] = input.value;
-      }
+    document.querySelectorAll("#plugin-params input").forEach((i) => {
+      if (i.value) params[i.name] = i.value;
     });
-
     try {
       const result = await api.post(`/api/workspace/${this.workspaceId}/load`, {
         plugin: pluginId,
-        params: params,
+        params,
       });
-
-      if (result.error) {
-        showNotification(result.error, "error");
-      } else {
-        showNotification(`Loaded ${result.node_count} nodes`, "success");
-        await this._refreshVisualization();
-      }
-    } catch (error) {
+      result.error
+        ? showNotification(result.error, "error")
+        : (showNotification(`Loaded ${result.node_count} nodes`, "success"),
+          await this._refreshVisualization());
+    } catch (e) {
       showNotification("Failed to load data", "error");
-      console.error(error);
+      console.error(e);
     }
   }
 
-  /**
-   * Refresh all visualizations
-   */
   async _refreshVisualization() {
     try {
-      const graphData = await api.get(
+      this.graphData = await api.get(
         `/api/workspace/${this.workspaceId}/graph`,
       );
-      this.graphData = graphData;
-
       const visualizer = document.getElementById("visualizer-select").value;
       const renderResult = await api.get(
         `/api/workspace/${this.workspaceId}/render?visualizer=${visualizer}`,
@@ -213,84 +145,62 @@ class WorkspaceController {
       const mainContainer = document.getElementById("main-graph-container");
       mainContainer.innerHTML = renderResult.html || "";
 
-      mainContainer.querySelectorAll("script").forEach((old) => {
-        const s = document.createElement("script");
-        s.textContent = old.textContent;
-        document.body.appendChild(s);
-        document.body.removeChild(s);
-      });
+      // Make graph data available to plugins that want it
+      window.__graphData = this.graphData;
+
+      mainContainer
+        .querySelectorAll("script:not([type]), script[type='text/javascript']")
+        .forEach((old) => {
+          const s = document.createElement("script");
+          s.textContent = old.textContent;
+          document.body.appendChild(s);
+          document.body.removeChild(s);
+        });
 
       setTimeout(() => {
-        const existingSvg = mainContainer.querySelector("svg");
-
-        if (graphData.nodes.length > 0) {
-          if (existingSvg) {
-            console.log("calling attach...");
-            this.graphRenderer.attach(existingSvg.id, graphData);
-          } else {
-            console.log("NO SVG FOUND");
-          }
-        } else {
-          console.log("NO NODES");
+        const svgEl = mainContainer.querySelector("svg");
+        if (this.graphData.nodes.length > 0 && svgEl) {
+          this.graphRenderer.attach(svgEl.id, this.graphData);
         }
-
         this.birdView.render(this.graphData);
       }, 50);
-    } catch (error) {
-      console.error("Failed to refresh visualization:", error);
+    } catch (e) {
+      console.error("Failed to refresh visualization:", e);
     }
   }
-  /**
-   * Handle search
-   */
+
   async _handleSearch(query) {
     if (!query) return;
-
     try {
       const result = await api.post(
         `/api/workspace/${this.workspaceId}/search`,
         { query },
       );
-
-      if (result.error) {
-        showNotification(result.error, "error");
-      } else {
-        showNotification(`Found ${result.node_count} nodes`, "info");
-        await this._refreshVisualization();
-      }
-    } catch (error) {
+      result.error
+        ? showNotification(result.error, "error")
+        : (showNotification(`Found ${result.node_count} nodes`, "info"),
+          await this._refreshVisualization());
+    } catch (e) {
       showNotification("Search failed", "error");
-      console.error(error);
     }
   }
 
-  /**
-   * Handle filter
-   */
   async _handleFilter(query) {
     if (!query) return;
-
     try {
       const result = await api.post(
         `/api/workspace/${this.workspaceId}/filter`,
         { query },
       );
-
-      if (result.error) {
-        showNotification(result.error, "error");
-      } else {
-        showNotification(`Filtered to ${result.node_count} nodes`, "info");
-        await this._refreshVisualization();
-      }
-    } catch (error) {
+      result.error
+        ? showNotification(result.error, "error")
+        : (showNotification(`Filtered to ${result.node_count} nodes`, "info"),
+          await this._refreshVisualization());
+    } catch (e) {
       showNotification("Filter failed", "error");
-      console.error(error);
     }
   }
 
-  /**
-   * Handle reset
-   */
   async _handleReset() {
     try {
       await api.post(`/api/workspace/${this.workspaceId}/reset`);
@@ -298,44 +208,30 @@ class WorkspaceController {
       document.getElementById("filter-input").value = "";
       await this._refreshVisualization();
       showNotification("Reset to original graph", "info");
-    } catch (error) {
+    } catch (e) {
       showNotification("Reset failed", "error");
-      console.error(error);
     }
   }
 
-  /**
-   * Handle CLI command
-   */
   async _handleCliCommand(command) {
     if (!command) return;
-
     const output = document.getElementById("cli-output");
     output.innerHTML += `<div class="cli-command">&gt; ${command}</div>`;
-
     try {
       const result = await api.post(`/api/workspace/${this.workspaceId}/cli`, {
         command,
       });
-
-      if (result.error) {
-        output.innerHTML += `<div class="cli-error">${result.error}</div>`;
-      } else {
-        output.innerHTML += `<div class="cli-result">${result.result || "OK"}</div>`;
-        await this._refreshVisualization();
-      }
-    } catch (error) {
+      output.innerHTML += result.error
+        ? `<div class="cli-error">${result.error}</div>`
+        : `<div class="cli-result">${result.result || "OK"}</div>`;
+      if (!result.error) await this._refreshVisualization();
+    } catch (e) {
       output.innerHTML += `<div class="cli-error">Command failed</div>`;
     }
-
-    // Scroll to bottom
     output.scrollTop = output.scrollHeight;
   }
 }
 
-// Initialize when DOM is ready
 document.addEventListener("DOMContentLoaded", () => {
-  if (document.querySelector(".workspace-page")) {
-    new WorkspaceController();
-  }
+  if (document.querySelector(".workspace-page")) new WorkspaceController();
 });

--- a/json-datasource/src/tangled_json_datasource/plugin.py
+++ b/json-datasource/src/tangled_json_datasource/plugin.py
@@ -54,7 +54,7 @@ def _to_attribute_value(key: str, value: Any) -> Optional[Any]:
         return parsed if parsed is not None else value
     if isinstance(value, list):
         if not value:
-            return ""
+            return None
         if all(isinstance(v, (int, float, str, bool)) or v is None for v in value):
             parts = []
             for v in value:
@@ -223,6 +223,8 @@ class JsonDataSource(DataSourcePlugin):
             node = Node(id=node_id)
 
             for key, value in obj.items():
+                if key == id_attribute:
+                    continue
                 if value is None:
                     continue
                 if isinstance(value, dict):

--- a/json-datasource/tests/examples/acyclic_tree.json
+++ b/json-datasource/tests/examples/acyclic_tree.json
@@ -1,22 +1,31 @@
-{
-  "id": "id1",
-  "first": "John",
-  "last": "Doe",
-  "years": 53,
-  "children": [
-    {
-      "id": "id2",
-      "first": "Mike",
-      "last": "Doe",
-      "years": 25,
-      "children": []
-    },
-    {
-      "id": "id3",
-      "first": "Lucy",
-      "last": "Doe",
-      "years": 15,
-      "children": []
-    }
-  ]
-}
+[
+  {
+    "id": "id1",
+    "first": "John",
+    "last": "Doe",
+    "years": 53,
+    "children": [
+      {
+        "id": "id2",
+        "first": "Mike",
+        "last": "Doe",
+        "years": 25,
+        "children": []
+      },
+      {
+        "id": "id3",
+        "first": "Lucy",
+        "last": "Doe",
+        "years": 15,
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "id4",
+    "first": "Anna",
+    "last": "Smith",
+    "years": 40,
+    "children": []
+  }
+]

--- a/json-datasource/tests/test_plugin.py
+++ b/json-datasource/tests/test_plugin.py
@@ -24,7 +24,7 @@ class TestJsonDataSourceLoad:
             base_path=str(EXAMPLES_DIR),
             id_attribute="id",
         )
-        assert len(graph.nodes) == 3
+        assert len(graph.nodes) == 4
         assert len(graph.edges) == 2
 
         n1 = graph.get_node("id1")


### PR DESCRIPTION
Hi team 👋

This PR implements the BlockVisualizer plugin and improves its HTML/SVG output and Python implementation for graph visualization.

What’s included:
- Jinja2 template (template/template.html) for HTML/SVG generation.
- Improved SVG styling (colored headers, alternating rows, cleaner node/edge visuals).
- Standardized SVG font to Arial, sans-serif and cleaned up CSS for better maintainability.
- Improved node dragging behavior.
- Added boundary constraints so nodes can’t leave the main frame (no flying off infinitely).
- Selective node rendering - nodes are loaded/displayed dynamically depending on zoom level and viewport, so not everything is visible at once (for better UX).
- Tests for plugin

Let me know if you’d like anything adjusted 👍
Closes #17 