### PR TITLE
Fix CSS issues and apply minor culling optimizations

### DIFF
--- a/block-visualizer/src/tangled_block_visualizer/template/template.html
+++ b/block-visualizer/src/tangled_block_visualizer/template/template.html
@@ -70,6 +70,16 @@
       return HEADER_H + Math.max(1, getAttrs(d).length) * ROW_H + 4;
     }
 
+    function measureText(svg, text, fontSize) {
+      const tmp = svg.append('text')
+        .attr('font-size', fontSize || FONT_SIZE)
+        .attr('font-family', 'Arial, sans-serif')
+        .text(text);
+      const w = tmp.node().getComputedTextLength();
+      tmp.remove();
+      return w;
+    }
+
     function render() {
 
       const svg = d3.select('#svg-{{name}}').attr('zoom', true);
@@ -89,7 +99,7 @@
         .attr('class', 'block-node')
         .attr('id', d => d.id);
 
-      /* Header text */
+      /* Header text – appended first so we can measure it */
       node.append('text')
         .attr('class', 'header-text')
         .attr('text-anchor', 'middle')
@@ -102,17 +112,23 @@
       node.each(function (d) {
 
         const grp = d3.select(this);
-
         const attrs = getAttrs(d);
 
         const textEl = this.querySelector('.header-text');
         const textW = textEl ? textEl.getComputedTextLength() : 100;
 
-        const nw = Math.max(160, textW + PAD_X * 2);
+        let maxAttrW = 0;
+        attrs.forEach(attr => {
+          const valW = measureText(svg, String(attr.value), FONT_SIZE);
+          const rowW = PAD_X + KEY_W + 8 + valW + PAD_X;
+          if (rowW > maxAttrW) maxAttrW = rowW;
+        });
+
+        const nw = Math.max(160, textW + PAD_X * 2, maxAttrW);
         const nh = nodeHeight(d);
         const topY = -nh / 2;
 
-        /* Node border */
+        /* Node border (full rounded rect, white fill) */
         grp.insert('rect', '.header-text')
           .attr('class', 'node-border')
           .attr('x', -nw / 2)
@@ -122,7 +138,17 @@
           .attr('rx', 4)
           .attr('ry', 4);
 
-        /* Header background */
+        /* Clip path to flatten the bottom edge of the header rect */
+        const clipId = `clip-header-${d.id}`;
+        grp.append('clipPath')
+          .attr('id', clipId)
+          .append('rect')
+          .attr('x', -nw / 2)
+          .attr('y', topY)
+          .attr('width', nw)
+          .attr('height', HEADER_H);
+
+        /* Header background – clipped so only top corners are rounded */
         grp.insert('rect', '.header-text')
           .attr('class', 'header-bg')
           .attr('x', -nw / 2)
@@ -130,15 +156,8 @@
           .attr('width', nw)
           .attr('height', HEADER_H)
           .attr('rx', 4)
-          .attr('ry', 4);
-
-        /* Header patch */
-        grp.insert('rect', '.header-text')
-          .attr('class', 'header-bg')
-          .attr('x', -nw / 2)
-          .attr('y', topY + HEADER_H - 6)
-          .attr('width', nw)
-          .attr('height', 6);
+          .attr('ry', 4)
+          .attr('clip-path', `url(#${clipId})`);
 
         /* Header text position */
         grp.select('.header-text')

--- a/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
@@ -91,19 +91,27 @@ class GraphRenderer {
     this._lastNodeBounds = nodeBounds;
     const nodeRadius = this._detectNodeRadius(svgEl, nodeSelector);
 
+    const FALLBACK_HW = nodeRadius;
+    const FALLBACK_HH = nodeRadius;
+
     let currentTransform = d3.zoomIdentity;
 
-    // 150px screen-space buffer prevents pop-in at edges
+    // Returns the visible rectangle in world-space coordinates
     const getVisibleWorldRect = (t) => {
       const { k, x: tx, y: ty } = t;
-      const buf = 150 / k;
       return {
-        left: (0 - tx) / k - buf,
-        right: (w - tx) / k + buf,
-        top: (0 - ty) / k - buf,
-        bottom: (h - ty) / k + buf,
+        left: (0 - tx) / k,
+        right: (w - tx) / k,
+        top: (0 - ty) / k,
+        bottom: (h - ty) / k,
       };
     };
+
+    const boxOverlapsRect = (cx, cy, hw, hh, rect) =>
+      cx + hw >= rect.left &&
+      cx - hw <= rect.right &&
+      cy + hh >= rect.top &&
+      cy - hh <= rect.bottom;
 
     const applyCulling = (t) => {
       const rect = getVisibleWorldRect(t);
@@ -112,25 +120,35 @@ class GraphRenderer {
         const id = d3.select(this).attr("id");
         const node = nodeById.get(id);
         if (!node) return;
-        const visible =
-          node.x >= rect.left &&
-          node.x <= rect.right &&
-          node.y >= rect.top &&
-          node.y <= rect.bottom;
-        this.style.visibility = visible ? "visible" : "hidden";
+
+        const b = nodeBounds.get(id);
+        const hw = b ? b.hw : FALLBACK_HW;
+        const hh = b ? b.hh : FALLBACK_HH;
+
+        this.style.visibility = boxOverlapsRect(node.x, node.y, hw, hh, rect)
+          ? "visible"
+          : "hidden";
       });
 
       linkSelection.each(function (d) {
-        const srcVisible =
-          d.source.x >= rect.left &&
-          d.source.x <= rect.right &&
-          d.source.y >= rect.top &&
-          d.source.y <= rect.bottom;
-        const tgtVisible =
-          d.target.x >= rect.left &&
-          d.target.x <= rect.right &&
-          d.target.y >= rect.top &&
-          d.target.y <= rect.bottom;
+        const sb = nodeBounds.get(d.source.id);
+        const tb = nodeBounds.get(d.target.id);
+
+        const srcVisible = boxOverlapsRect(
+          d.source.x,
+          d.source.y,
+          sb ? sb.hw : FALLBACK_HW,
+          sb ? sb.hh : FALLBACK_HH,
+          rect,
+        );
+        const tgtVisible = boxOverlapsRect(
+          d.target.x,
+          d.target.y,
+          tb ? tb.hw : FALLBACK_HW,
+          tb ? tb.hh : FALLBACK_HH,
+          rect,
+        );
+
         this.style.visibility = srcVisible || tgtVisible ? "visible" : "hidden";
       });
     };


### PR DESCRIPTION
Hi team 👋

This PR improves Block Visualizer layout accuracy and Graph Explorer rendering.

- Added dynamic text measurement for precise node sizing.
- Fixed attribute overflow and refined header rendering.
- Improved node/link culling using bounding boxes for more accurate visibility.

Let me know if you’d like any changes 👍

Closes #21 