### PR TITLE
Feat: Kuzu datasource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ run:
 	$(VENV) tangled --port=$(PORT)
 
 test:
-	$(VENV) pip install -q -e "./api[dev]" -e "./platform[dev]" -e "./json-datasource[dev]" -e "./yaml-datasource[dev]" && \
-	$(VENV) pytest api/src/tests/ json-datasource/tests/ yaml-datasource/tests/ -v
+	$(VENV) pip install -q -e "./api[dev]" -e "./platform[dev]" -e "./json-datasource[dev]" -e "./yaml-datasource[dev]" -e "./kuzu-datasource[dev]" && \
+	$(VENV) pytest api/src/tests/ json-datasource/tests/ yaml-datasource/tests/ kuzu-datasource/tests/ -v
 
 lint:
 	$(VENV) pip install -q -e "./api[dev]" -e "./platform[dev]" && \
@@ -36,7 +36,7 @@ reinstall:
 
 clean:
 	rm -rf venv .pytest_cache
-	@for dir in api platform json-datasource yaml-datasource xml-datasource simple-visualizer block-visualizer graph-explorer; do \
+	@for dir in api platform json-datasource yaml-datasource kuzu-datasource xml-datasource simple-visualizer block-visualizer graph-explorer; do \
 		find $$dir -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true; \
 		find $$dir -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true; \
 		find $$dir -type d -name "build" -exec rm -rf {} + 2>/dev/null || true; \

--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ tangled/
 │   └── src/tangled_platform/ # Plugin discovery, workspaces, CLI
 ├── json-datasource/          # JSON data source plugin
 │   └── src/tangled_json_datasource/
+├── yaml-datasource/          # YAML data source plugin
+│   └── src/tangled_yaml_datasource/
 ├── xml-datasource/           # XML data source plugin
 │   └── src/tangled_xml_datasource/
+├── kuzu-datasource/          # Kuzu graph database data source plugin
+│   └── src/tangled_kuzu_datasource/
 ├── simple-visualizer/        # Simple circle-based visualizer
 │   └── src/tangled_simple_visualizer/
 ├── block-visualizer/         # Block/rectangle visualizer with attributes
@@ -31,7 +35,7 @@ tangled/
 
 ## Features
 
-- **Multiple Data Sources**: Load graphs from JSON, XML (extensible via plugins)
+- **Multiple Data Sources**: Load graphs from JSON, YAML, XML, and Kuzu databases (extensible via plugins)
 - **Multiple Visualizers**: Simple and Block views (extensible via plugins)
 - **Three View Modes**: Main View, Tree View, Bird View (synchronized)
 - **Search & Filter**: Query-based graph filtering
@@ -95,7 +99,9 @@ source venv/bin/activate   # Windows: .\venv\Scripts\Activate.ps1
 pip install -e ./api
 pip install -e ./platform
 pip install -e ./json-datasource
+pip install -e ./yaml-datasource
 pip install -e ./xml-datasource
+pip install -e ./kuzu-datasource
 pip install -e ./simple-visualizer
 pip install -e ./block-visualizer
 pip install -e ./graph-explorer

--- a/graph-explorer/pyproject.toml
+++ b/graph-explorer/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "tangled-json-datasource",
     "tangled-yaml-datasource",
     "tangled-xml-datasource",
+    "tangled-kuzu-datasource",
     "tangled-simple-visualizer",
     "tangled-block-visualizer",
 ]

--- a/kuzu-datasource/README.md
+++ b/kuzu-datasource/README.md
@@ -1,0 +1,55 @@
+# Tangled Kuzu Data Source
+
+A data source plugin for the [Tangled](https://github.com/re-pixel/tangled) graph visualization platform that reads graph data from [Kuzu](https://kuzudb.com/) embedded graph databases.
+
+## Features
+
+- Reads Kuzu databases in read-only mode (no server required)
+- Executes Cypher queries to extract nodes and relationships
+- Maps Kuzu types (INT64, DOUBLE, STRING, DATE, BOOLEAN) to Tangled attribute types
+- Configurable node ID property and custom queries
+- Supports cyclic and acyclic graph structures
+
+## Installation
+
+```bash
+pip install tangled-kuzu-datasource
+```
+
+Or for development:
+
+```bash
+pip install -e "./kuzu-datasource[dev]"
+```
+
+## Usage
+
+```python
+from tangled_kuzu_datasource import KuzuDataSource
+
+plugin = KuzuDataSource()
+
+# Load with defaults (matches all nodes and relationships)
+graph = plugin.load(database_path="/path/to/kuzu/db")
+
+# Load with a custom Cypher query
+graph = plugin.load(
+    database_path="/path/to/kuzu/db",
+    query="MATCH (p:Person)-[r:KNOWS]->(q:Person) RETURN p, r, q",
+    node_id_property="name",
+)
+```
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `database_path` | str | Yes | — | Path to the Kuzu database directory |
+| `query` | str | No | `MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m` | Cypher query to execute |
+| `node_id_property` | str | No | `id` | Node property to use as Tangled node ID |
+
+## Running Tests
+
+```bash
+pytest kuzu-datasource/tests/ -v
+```

--- a/kuzu-datasource/pyproject.toml
+++ b/kuzu-datasource/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tangled-kuzu-datasource"
+version = "0.1.0"
+description = "Kuzu graph database data source plugin for Tangled graph visualization platform"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "tangled-api",
+    "kuzu>=0.8.0",
+]
+
+[project.entry-points."tangled.datasource"]
+kuzu = "tangled_kuzu_datasource:KuzuDataSource"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/kuzu-datasource/src/tangled_kuzu_datasource/__init__.py
+++ b/kuzu-datasource/src/tangled_kuzu_datasource/__init__.py
@@ -1,0 +1,11 @@
+"""
+Kuzu Data Source Plugin for Tangled.
+
+Reads graph data from Kuzu embedded graph databases using Cypher queries.
+"""
+
+__version__ = "0.1.0"
+
+from tangled_kuzu_datasource.plugin import KuzuDataSource
+
+__all__ = ["KuzuDataSource"]

--- a/kuzu-datasource/src/tangled_kuzu_datasource/plugin.py
+++ b/kuzu-datasource/src/tangled_kuzu_datasource/plugin.py
@@ -1,0 +1,240 @@
+"""
+Kuzu Data Source Plugin implementation.
+
+Reads graph data from Kuzu embedded graph databases using Cypher queries.
+Nodes and relationships returned by the query are mapped to Tangled's
+Graph model with typed attributes (int, float, str, date).
+"""
+
+from datetime import date, datetime
+from typing import Any, List, Optional, Tuple, Union
+
+import kuzu
+
+from tangled_api.model import Graph, Node, Edge
+from tangled_api.plugins import DataSourcePlugin, PluginParameter
+
+_DEFAULT_QUERY = "MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m"
+_DEFAULT_NODE_ID_PROPERTY = "id"
+
+
+def _to_attribute_value(key: str, value: Any) -> Optional[Any]:
+    """
+    Convert a Kuzu property value to a Tangled attribute type (int, float, str, date).
+
+    Returns None for null/unsupported types (skip).
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, list):
+        if not value:
+            return ""
+        if all(isinstance(v, (int, float, str, bool)) or v is None for v in value):
+            parts = []
+            for v in value:
+                if v is None:
+                    parts.append("")
+                elif isinstance(v, bool):
+                    parts.append(str(v).lower())
+                else:
+                    parts.append(str(v))
+            return ",".join(parts)
+        return None
+    return None
+
+
+def _apply_attributes(entity: Union[Node, Edge], props: dict) -> None:
+    """Copy non-internal properties from a Kuzu dict onto a Node or Edge."""
+    for key, value in props.items():
+        if key.startswith("_"):
+            continue
+        attr_val = _to_attribute_value(key, value)
+        if attr_val is not None:
+            try:
+                entity.set_attribute(key, attr_val)
+            except (ValueError, TypeError):
+                pass
+
+
+def _is_node(value: Any) -> bool:
+    """Detect whether a query result value is a Kuzu node."""
+    return (
+        isinstance(value, dict)
+        and "_label" in value
+        and "_id" in value
+        and "_src" not in value
+    )
+
+
+def _is_relationship(value: Any) -> bool:
+    """Detect whether a query result value is a Kuzu relationship."""
+    return isinstance(value, dict) and "_src" in value and "_dst" in value
+
+
+def _to_hashable_id(internal_id: Any) -> Tuple:
+    """Convert Kuzu internal IDs (dicts/tuples) to hashable keys for deduplication."""
+    if isinstance(internal_id, dict):
+        return (internal_id.get("offset"), internal_id.get("table"))
+    if isinstance(internal_id, (list, tuple)):
+        return tuple(internal_id)
+    return (internal_id,)
+
+
+class KuzuDataSource(DataSourcePlugin):
+    """
+    Data source plugin that reads graph data from Kuzu embedded graph databases.
+
+    Opens the database in read-only mode and executes a Cypher query to extract
+    nodes and relationships, mapping them to Tangled's Graph model.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Kuzu Data Source"
+
+    @property
+    def description(self) -> str:
+        return "Reads graph data from Kuzu embedded graph databases using Cypher queries."
+
+    @property
+    def parameters(self) -> List[PluginParameter]:
+        return [
+            PluginParameter(
+                name="database_path",
+                param_type=str,
+                description="Path to the Kuzu database directory",
+                required=True,
+            ),
+            PluginParameter(
+                name="query",
+                param_type=str,
+                description="Cypher query to execute (default: match all nodes and relationships)",
+                required=False,
+                default=_DEFAULT_QUERY,
+            ),
+            PluginParameter(
+                name="node_id_property",
+                param_type=str,
+                description="Node property to use as Tangled node ID (default: id)",
+                required=False,
+                default=_DEFAULT_NODE_ID_PROPERTY,
+            ),
+        ]
+
+    def load(self, **params: Any) -> Graph:
+        """
+        Read a Kuzu database and construct a graph.
+
+        Args:
+            database_path: Path to the Kuzu database directory
+            query: Cypher query to execute
+            node_id_property: Node property to use as Tangled node ID
+
+        Returns:
+            Graph constructed from query results
+
+        Raises:
+            ValueError: If parameters are invalid or query fails
+        """
+        database_path = params.get("database_path")
+        query = params.get("query", _DEFAULT_QUERY)
+        node_id_property = params.get("node_id_property", _DEFAULT_NODE_ID_PROPERTY)
+
+        if not database_path:
+            raise ValueError("database_path parameter is required")
+
+        try:
+            db = kuzu.Database(database_path, read_only=True)
+        except Exception as e:
+            raise ValueError(f"Database not found: {database_path}") from e
+
+        conn = kuzu.Connection(db)
+
+        try:
+            result = conn.execute(query)
+        except Exception as e:
+            raise ValueError(f"Invalid Cypher query: {e}") from e
+
+        graph = Graph(directed=True)
+        seen_nodes = set()
+        node_id_map = {}
+        rels_to_add = []
+
+        # Single pass: process nodes inline, buffer relationships
+        while result.has_next():
+            row = result.get_next()
+            for value in row:
+                if value is None:
+                    continue
+                if _is_node(value):
+                    h_id = _to_hashable_id(value.get("_id"))
+                    if h_id in seen_nodes:
+                        continue
+                    seen_nodes.add(h_id)
+
+                    label = value.get("_label", "Unknown")
+
+                    if node_id_property in value:
+                        tangled_id = str(value[node_id_property])
+                    else:
+                        internal_id = value.get("_id")
+                        offset = (
+                            internal_id.get("offset", 0)
+                            if isinstance(internal_id, dict)
+                            else 0
+                        )
+                        tangled_id = f"{label}_{offset}"
+
+                    node_id_map[h_id] = tangled_id
+                    node = Node(id=tangled_id)
+                    node.set_attribute("_label", label)
+                    _apply_attributes(node, value)
+                    graph.add_node(node)
+
+                elif _is_relationship(value):
+                    rels_to_add.append(value)
+
+        # Second pass: add edges (must happen after all nodes exist)
+        seen_edges = set()
+        edge_counter = 0
+
+        for rel_dict in rels_to_add:
+            src_id = _to_hashable_id(rel_dict.get("_src"))
+            dst_id = _to_hashable_id(rel_dict.get("_dst"))
+            rel_internal_id = _to_hashable_id(rel_dict.get("_id"))
+
+            edge_key = (src_id, rel_internal_id, dst_id)
+            if edge_key in seen_edges:
+                continue
+            seen_edges.add(edge_key)
+
+            source_tangled_id = node_id_map.get(src_id)
+            target_tangled_id = node_id_map.get(dst_id)
+
+            if source_tangled_id is None or target_tangled_id is None:
+                continue
+
+            edge = Edge(
+                id=f"e{edge_counter}",
+                source_id=source_tangled_id,
+                target_id=target_tangled_id,
+            )
+            edge_counter += 1
+
+            edge.set_attribute("_type", rel_dict.get("_label", "Unknown"))
+            _apply_attributes(edge, rel_dict)
+            graph.add_edge(edge)
+
+        return graph

--- a/kuzu-datasource/tests/conftest.py
+++ b/kuzu-datasource/tests/conftest.py
@@ -1,0 +1,151 @@
+"""
+Pytest fixtures for Kuzu Data Source plugin tests.
+
+Creates temporary Kuzu databases programmatically since Kuzu databases
+are binary/platform-specific and cannot be committed as test fixtures.
+"""
+
+from datetime import date, timedelta
+
+import kuzu
+import pytest
+
+from tangled_kuzu_datasource import KuzuDataSource
+
+
+@pytest.fixture
+def plugin():
+    return KuzuDataSource()
+
+
+@pytest.fixture
+def acyclic_db(tmp_path):
+    """3 Person nodes (John/Mike/Lucy Doe), 2 CHILD_OF edges. No cycles."""
+    db_path = str(tmp_path / "acyclic_db")
+    db = kuzu.Database(db_path)
+    conn = kuzu.Connection(db)
+    conn.execute(
+        "CREATE NODE TABLE Person("
+        "id STRING, first STRING, last STRING, years INT64, "
+        "PRIMARY KEY(id))"
+    )
+    conn.execute("CREATE REL TABLE CHILD_OF(FROM Person TO Person)")
+    conn.execute(
+        'CREATE (:Person {id: "id1", first: "John", last: "Doe", years: 53})'
+    )
+    conn.execute(
+        'CREATE (:Person {id: "id2", first: "Mike", last: "Doe", years: 25})'
+    )
+    conn.execute(
+        'CREATE (:Person {id: "id3", first: "Lucy", last: "Doe", years: 27})'
+    )
+    conn.execute(
+        'MATCH (a:Person {id: "id2"}), (b:Person {id: "id1"}) '
+        "CREATE (a)-[:CHILD_OF]->(b)"
+    )
+    conn.execute(
+        'MATCH (a:Person {id: "id3"}), (b:Person {id: "id1"}) '
+        "CREATE (a)-[:CHILD_OF]->(b)"
+    )
+    del conn
+    del db
+    return db_path
+
+
+@pytest.fixture
+def cyclic_db(tmp_path):
+    """3 Person nodes, 2 HAS_CHILD + 2 HAS_PARENT edges creating cycles."""
+    db_path = str(tmp_path / "cyclic_db")
+    db = kuzu.Database(db_path)
+    conn = kuzu.Connection(db)
+    conn.execute(
+        "CREATE NODE TABLE Person("
+        "id STRING, first STRING, last STRING, "
+        "PRIMARY KEY(id))"
+    )
+    conn.execute("CREATE REL TABLE HAS_CHILD(FROM Person TO Person)")
+    conn.execute("CREATE REL TABLE HAS_PARENT(FROM Person TO Person)")
+    conn.execute('CREATE (:Person {id: "p1", first: "John", last: "Doe"})')
+    conn.execute('CREATE (:Person {id: "p2", first: "Mike", last: "Doe"})')
+    conn.execute('CREATE (:Person {id: "p3", first: "Lucy", last: "Doe"})')
+    # John -> Mike, John -> Lucy (HAS_CHILD)
+    conn.execute(
+        'MATCH (a:Person {id: "p1"}), (b:Person {id: "p2"}) '
+        "CREATE (a)-[:HAS_CHILD]->(b)"
+    )
+    conn.execute(
+        'MATCH (a:Person {id: "p1"}), (b:Person {id: "p3"}) '
+        "CREATE (a)-[:HAS_CHILD]->(b)"
+    )
+    # Mike -> John, Lucy -> John (HAS_PARENT) — creates cycles
+    conn.execute(
+        'MATCH (a:Person {id: "p2"}), (b:Person {id: "p1"}) '
+        "CREATE (a)-[:HAS_PARENT]->(b)"
+    )
+    conn.execute(
+        'MATCH (a:Person {id: "p3"}), (b:Person {id: "p1"}) '
+        "CREATE (a)-[:HAS_PARENT]->(b)"
+    )
+    del conn
+    del db
+    return db_path
+
+
+@pytest.fixture
+def large_db(tmp_path):
+    """210 Employee nodes with hierarchical REPORTS_TO edges and varied types."""
+    db_path = str(tmp_path / "large_db")
+    db = kuzu.Database(db_path)
+    conn = kuzu.Connection(db)
+    conn.execute(
+        "CREATE NODE TABLE Employee("
+        "id STRING, name STRING, level INT64, salary DOUBLE, "
+        "start_date DATE, PRIMARY KEY(id))"
+    )
+    conn.execute("CREATE REL TABLE REPORTS_TO(FROM Employee TO Employee)")
+
+    base_date = date(2020, 1, 1)
+    for i in range(210):
+        eid = f"emp{i}"
+        name = f"Employee_{i}"
+        level = i % 5
+        salary = 50000.0 + i * 100
+        d = (base_date + timedelta(days=i)).isoformat()
+        conn.execute(
+            f"CREATE (:Employee {{id: \"{eid}\", name: \"{name}\", "
+            f"level: {level}, salary: {salary}, "
+            f"start_date: date('{d}')}})"
+        )
+
+    # Hierarchy: employee i reports to employee i//10 (for i > 0)
+    for i in range(1, 210):
+        manager = i // 10
+        conn.execute(
+            f'MATCH (a:Employee {{id: "emp{i}"}}), '
+            f'(b:Employee {{id: "emp{manager}"}}) '
+            f"CREATE (a)-[:REPORTS_TO]->(b)"
+        )
+
+    del conn
+    del db
+    return db_path
+
+
+@pytest.fixture
+def types_db(tmp_path):
+    """1 node with INT64, DOUBLE, STRING, DATE, BOOLEAN columns for type tests."""
+    db_path = str(tmp_path / "types_db")
+    db = kuzu.Database(db_path)
+    conn = kuzu.Connection(db)
+    conn.execute(
+        "CREATE NODE TABLE TypeTest("
+        "id STRING, int_val INT64, float_val DOUBLE, str_val STRING, "
+        "date_val DATE, bool_val BOOLEAN, PRIMARY KEY(id))"
+    )
+    conn.execute(
+        "CREATE (:TypeTest {id: \"t1\", int_val: 42, float_val: 3.14, "
+        "str_val: \"hello\", date_val: date('2024-01-15'), bool_val: true})"
+    )
+    del conn
+    del db
+    return db_path

--- a/kuzu-datasource/tests/test_kuzu_plugin.py
+++ b/kuzu-datasource/tests/test_kuzu_plugin.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for Kuzu Data Source plugin.
+
+Run with: pytest tests/ -v
+"""
+
+import pytest
+from datetime import date
+
+
+class TestKuzuDataSourceLoad:
+    """Test loading Kuzu databases into graphs."""
+
+    def test_acyclic_tree_loads(self, plugin, acyclic_db):
+        """Acyclic tree (Doe family) produces correct nodes and edges."""
+        graph = plugin.load(database_path=acyclic_db)
+
+        assert len(graph.nodes) == 3
+        assert len(graph.edges) == 2
+
+        n1 = graph.get_node("id1")
+        assert n1 is not None
+        assert n1.get_attribute_value("first") == "John"
+        assert n1.get_attribute_value("last") == "Doe"
+        assert n1.get_attribute_value("years") == 53
+
+    def test_cyclic_loads(self, plugin, cyclic_db):
+        """Cyclic graph produces correct nodes and edges."""
+        graph = plugin.load(database_path=cyclic_db)
+
+        assert len(graph.nodes) == 3
+        assert len(graph.edges) == 4
+
+    def test_large_demo_meets_minimum_nodes(self, plugin, large_db):
+        """Large demo has minimum 200 nodes per specification."""
+        graph = plugin.load(database_path=large_db)
+
+        assert len(graph.nodes) >= 200
+
+
+class TestKuzuDataSourceValidation:
+    """Test parameter validation and error handling."""
+
+    def test_missing_database_path_raises(self, plugin):
+        with pytest.raises(ValueError, match="database_path parameter is required"):
+            plugin.load()
+
+    def test_database_not_found_raises(self, plugin):
+        with pytest.raises(ValueError, match="Database not found"):
+            plugin.load(database_path="/nonexistent/kuzu/db")
+
+    def test_invalid_query_raises(self, plugin, acyclic_db):
+        with pytest.raises(ValueError, match="Invalid Cypher query"):
+            plugin.load(database_path=acyclic_db, query="NOT A VALID QUERY !!!")
+
+
+class TestKuzuDataSourceTypes:
+    """Test type mapping from Kuzu types to Tangled attribute types."""
+
+    def test_integer_preserved(self, plugin, types_db):
+        """Kuzu INT64 is preserved as int."""
+        graph = plugin.load(database_path=types_db, node_id_property="id")
+        n = graph.get_node("t1")
+        assert n is not None
+        assert n.get_attribute_value("int_val") == 42
+        assert isinstance(n.get_attribute_value("int_val"), int)
+
+    def test_float_preserved(self, plugin, types_db):
+        """Kuzu DOUBLE is preserved as float."""
+        graph = plugin.load(database_path=types_db, node_id_property="id")
+        n = graph.get_node("t1")
+        assert n is not None
+        assert n.get_attribute_value("float_val") == pytest.approx(3.14)
+
+    def test_string_preserved(self, plugin, types_db):
+        """Kuzu STRING is preserved as str."""
+        graph = plugin.load(database_path=types_db, node_id_property="id")
+        n = graph.get_node("t1")
+        assert n is not None
+        assert n.get_attribute_value("str_val") == "hello"
+
+    def test_date_preserved(self, plugin, types_db):
+        """Kuzu DATE is preserved as date."""
+        graph = plugin.load(database_path=types_db, node_id_property="id")
+        n = graph.get_node("t1")
+        assert n is not None
+        val = n.get_attribute_value("date_val")
+        assert isinstance(val, date)
+        assert val == date(2024, 1, 15)
+
+
+class TestKuzuDataSourceCyclic:
+    """Test cyclic graph detection."""
+
+    def test_graph_has_cycle(self, plugin, cyclic_db):
+        """Cyclic database produces a graph with cycles."""
+        graph = plugin.load(database_path=cyclic_db)
+        assert graph.has_cycle() is True
+
+    def test_parent_appears_as_source_and_target(self, plugin, cyclic_db):
+        """Parent node appears as both edge source and edge target."""
+        graph = plugin.load(database_path=cyclic_db)
+
+        source_ids = {e.source_id for e in graph.edges.values()}
+        target_ids = {e.target_id for e in graph.edges.values()}
+        assert "p1" in source_ids
+        assert "p1" in target_ids
+
+
+class TestKuzuDataSourceCustomQuery:
+    """Test custom Cypher queries."""
+
+    def test_custom_query_filters_nodes(self, plugin, acyclic_db):
+        """Custom query returns a subset of nodes."""
+        graph = plugin.load(
+            database_path=acyclic_db,
+            query='MATCH (n:Person) WHERE n.years > 26 RETURN n',
+        )
+        # John (53) and Lucy (27) match; Mike (25) does not
+        assert len(graph.nodes) == 2
+        assert graph.get_node("id1") is not None  # John
+        assert graph.get_node("id3") is not None  # Lucy
+
+    def test_node_only_query(self, plugin, acyclic_db):
+        """Query returning only nodes produces a graph with no edges."""
+        graph = plugin.load(
+            database_path=acyclic_db,
+            query="MATCH (n:Person) RETURN n",
+        )
+        assert len(graph.nodes) == 3
+        assert len(graph.edges) == 0
+
+
+class TestKuzuDataSourcePluginInterface:
+    """Test plugin interface (name, description, parameters)."""
+
+    def test_plugin_has_name_and_description(self, plugin):
+        assert plugin.name == "Kuzu Data Source"
+        assert "Kuzu" in plugin.description
+
+    def test_plugin_parameters(self, plugin):
+        param_names = [p.name for p in plugin.parameters]
+        assert "database_path" in param_names
+        assert "query" in param_names
+        assert "node_id_property" in param_names
+
+        db_param = next(p for p in plugin.parameters if p.name == "database_path")
+        assert db_param.required is True
+
+        query_param = next(p for p in plugin.parameters if p.name == "query")
+        assert query_param.required is False
+        assert query_param.default is not None


### PR DESCRIPTION
This pull request adds support for Kuzu graph database as a new data source plugin for the Tangled graph visualization platform. It introduces the `kuzu-datasource` package, updates documentation and build/test scripts, and integrates the plugin into the platform. The main changes are grouped below.

**Kuzu Data Source Plugin Implementation:**

* Added new `kuzu-datasource` package containing the Kuzu data source plugin, including implementation (`plugin.py`), package initialization (`__init__.py`), and a comprehensive README describing features, usage, and parameters. [[1]](diffhunk://#diff-f21f7892ef3207df91fb294d6f26bf3fac2595455bd69694910c583acc7e5cc6R1-R55) [[2]](diffhunk://#diff-e1e35212d9d57bfaa374b4d2af7eaffcf4e1c6adc305aedb904b28f654fec04eR1-R11) [[3]](diffhunk://#diff-e179c72cc951cbd999d8286aef32fe3373bab802acc43c88eb81c79581618d00R1-R240)
* Added test fixtures for the Kuzu data source plugin, including programmatic creation of test databases for acyclic, cyclic, large, and type-varied graphs.

**Platform Integration and Build/Test Updates:**

* Updated `Makefile` to include `kuzu-datasource` in test and clean commands, ensuring proper installation and test coverage. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L27-R28) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L39-R39)
* Updated `graph-explorer/pyproject.toml` to declare `tangled-kuzu-datasource` as a dependency.
* Added `kuzu-datasource/pyproject.toml` for packaging and entry-point registration of the plugin.

**Documentation Updates:**

* Updated `README.md` to describe the new Kuzu data source plugin, installation instructions, and feature list. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R38) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R104)

These changes collectively enable Tangled to load and visualize graphs stored in Kuzu databases, expanding the platform's data source capabilities.