### PR TITLE
Feat/#33 node hover

### DIFF
--- a/graph-explorer-django/src/tangled_django/explorer/static/js/graph.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/graph.js
@@ -21,6 +21,18 @@ class GraphRenderer {
     // Callbacks for view synchronization
     this.onNodeSelect = null;
     this.onViewportChange = null;
+    this.tooltip = d3
+      .select("body")
+      .append("div")
+      .style("position", "absolute")
+      .style("background", "white")
+      .style("border", "1px solid #ccc")
+      .style("padding", "8px")
+      .style("border-radius", "4px")
+      .style("font-size", "12px")
+      .style("pointer-events", "none")
+      .style("z-index", "999999")
+      .style("opacity", 0);
   }
 
   /**
@@ -202,15 +214,29 @@ class GraphRenderer {
    * Show tooltip on hover
    */
   _showTooltip(event, node) {
-    // TODO: Implement tooltip UI
-    console.log("Node:", node);
+    let html = `<strong>${node.id}</strong><br/>`;
+
+    if (node.attributes) {
+      Object.entries(node.attributes).forEach(([k, v]) => {
+        const value = typeof v === "object" ? v.value : v;
+        html += `${k}: ${value}<br/>`;
+      });
+    }
+
+    this.tooltip
+      .html(html)
+      .style("left", event.pageX + 10 + "px")
+      .style("top", event.pageY + 10 + "px")
+      .transition()
+      .duration(200)
+      .style("opacity", 1);
   }
 
   /**
    * Hide tooltip
    */
   _hideTooltip() {
-    // TODO: Implement tooltip UI
+    this.tooltip.transition().duration(200).style("opacity", 0);
   }
 
   /**

--- a/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
@@ -21,6 +21,19 @@ class GraphRenderer {
     // Callbacks for view synchronization
     this.onNodeSelect = null;
     this.onViewportChange = null;
+
+    this.tooltip = d3
+      .select("body")
+      .append("div")
+      .style("position", "absolute")
+      .style("background", "white")
+      .style("border", "1px solid #ccc")
+      .style("padding", "8px")
+      .style("border-radius", "4px")
+      .style("font-size", "12px")
+      .style("pointer-events", "none")
+      .style("z-index", "999999")
+      .style("opacity", 0);
   }
 
   /**
@@ -202,15 +215,29 @@ class GraphRenderer {
    * Show tooltip on hover
    */
   _showTooltip(event, node) {
-    // TODO: Implement tooltip UI
-    console.log("Node:", node);
+    let html = `<strong>${node.id}</strong><br/>`;
+
+    if (node.attributes) {
+      Object.entries(node.attributes).forEach(([k, v]) => {
+        const value = typeof v === "object" ? v.value : v;
+        html += `${k}: ${value}<br/>`;
+      });
+    }
+
+    this.tooltip
+      .html(html)
+      .style("left", event.pageX + 10 + "px")
+      .style("top", event.pageY + 10 + "px")
+      .transition()
+      .duration(200)
+      .style("opacity", 1);
   }
 
   /**
    * Hide tooltip
    */
   _hideTooltip() {
-    // TODO: Implement tooltip UI
+    this.tooltip.transition().duration(200).style("opacity", 0);
   }
 
   /**


### PR DESCRIPTION
This pull request adds an interactive tooltip feature to the graph visualization in both the Django and Flask versions of the app. The tooltip displays node details when hovering, improving usability and making node attributes more accessible.

**Tooltip feature improvements:**

* Added a styled tooltip `div` to the DOM in both `graph-explorer-django/src/tangled_django/explorer/static/js/graph.js` and `graph-explorer/src/tangled_graph_explorer/static/js/graph.js`, with CSS for positioning, appearance, and hiding by default.
* Implemented logic in `_showTooltip` to display node details (ID and attributes) on hover, rendering attribute values and positioning the tooltip near the cursor.
* Added a smooth hide animation for the tooltip in `_hideTooltip`.

Closes #33 