### PR TITLE
Add node selection synchronization and documentation

### DIFF
--- a/PLUGIN_DEVELOPMENT.md
+++ b/PLUGIN_DEVELOPMENT.md
@@ -3,6 +3,7 @@
 This guide explains how to extend the Tangled architecture by creating new plugins. Tangled uses a **Microkernel Architecture** where the core platform is minimal, and strict functionality is added via plugins.
 
 There are currently two types of plugins you can build:
+
 1.  **Data Source Plugins**: Read files (JSON, CSV, XML, etc.) and convert them into a `Graph`.
 2.  **Visualizer Plugins**: Take a `Graph` and convert it into a generic representation (HTML/JSON) for rendering.
 
@@ -12,11 +13,12 @@ There are currently two types of plugins you can build:
 
 Before starting, understand that all plugins share a common language: **`tangled-api`**.
 Your plugin **must** depend on this package to access the core data structures:
-*   `Graph`
-*   `Node`
-*   `Edge`
-*   `DataSourcePlugin` (Base Class)
-*   `VisualizerPlugin` (Base Class)
+
+- `Graph`
+- `Node`
+- `Edge`
+- `DataSourcePlugin` (Base Class)
+- `VisualizerPlugin` (Base Class)
 
 ---
 
@@ -25,6 +27,7 @@ Your plugin **must** depend on this package to access the core data structures:
 Every plugin is a standalone Python project. Do not modify the existing `platform` or `api` code. Create a new folder for your plugin at the root of the workspace.
 
 **Recommended Structure:**
+
 ```text
 my-new-plugin/                  <-- Project Root
 ├── pyproject.toml              <-- Configuration & Entry Points
@@ -42,6 +45,7 @@ my-new-plugin/                  <-- Project Root
 **Goal:** Read a file format and return a `Graph` object.
 
 ### Step A: Configuration (`pyproject.toml`)
+
 Define your project and declare the dependency on `tangled-api`.
 
 ```toml
@@ -60,6 +64,7 @@ my_loader = "tangled_my_plugin.plugin:MyDataSource"
 ```
 
 ### Step B: Implementation (`plugin.py`)
+
 Inherit from `DataSourcePlugin` and implement `load()`.
 
 ```python
@@ -81,28 +86,42 @@ class MyDataSource(DataSourcePlugin):
         # Define arguments the user needs to provide in the UI/API
         return [
             PluginParameter(
-                name="filepath", 
-                param_type=str, 
-                description="Path to the file", 
+                name="filepath",
+                param_type=str,
+                description="Path to the file",
                 required=True
             )
         ]
 
     def load(self, **params: Any) -> Graph:
         filepath = params.get("filepath")
-        
+
         # 1. Create an empty graph
         graph = Graph(directed=True)
-        
+
         # 2. Your logic to read the file
         # with open(filepath) as f: ...
-        
+
         # 3. Populate the graph
         # graph.add_node(Node(id="a", attributes={"type": "demo"}))
         # graph.add_edge(Edge(id="e1", source_id="a", target_id="b"))
-        
+
         return graph
 ```
+
+### Graph directionality
+
+When implementing `load()`, read the `directed` flag from the source file instead of hardcoding it:
+
+```python
+# Good
+graph = Graph(directed=data.get("directed", True))
+
+# Avoid
+graph = Graph(directed=True)
+```
+
+Supported in JSON/YAML as a top-level `directed` key, and in XML as an attribute on the root element.
 
 ---
 
@@ -111,6 +130,7 @@ class MyDataSource(DataSourcePlugin):
 **Goal:** Take a `Graph` object and return an HTML string.
 
 ### Step A: Configuration (`pyproject.toml`)
+
 Same as above, but register under the `tangled.visualizer` group.
 
 ```toml
@@ -121,6 +141,7 @@ my_viz = "tangled_my_visualizer.plugin:MyVisualizer"
 ```
 
 ### Step B: Implementation (`plugin.py`)
+
 Inherit from `VisualizerPlugin` and implement `render()`.
 
 ```python
@@ -139,11 +160,11 @@ class MyVisualizer(VisualizerPlugin):
     def render(self, graph: Graph) -> str:
         # Generate HTML representation
         html = ["<ul>"]
-        
+
         for node_id, node in graph.nodes.items():
             label = node.attributes.get("label", node_id)
             html.append(f"<li>{label}</li>")
-            
+
         html.append("</ul>")
         return "\n".join(html)
 ```
@@ -155,11 +176,13 @@ class MyVisualizer(VisualizerPlugin):
 Once your code is written, you must install the plugin in "editable" mode so the Platform can discover the entry points.
 
 1.  **Activate your environment**:
+
     ```bash
     source venv/bin/activate   # Windows: .\venv\Scripts\Activate.ps1
     ```
 
 2.  **Install your plugin**:
+
     ```bash
     cd my-new-plugin
     pip install -e .
@@ -167,3 +190,31 @@ Once your code is written, you must install the plugin in "editable" mode so the
 
 3.  **Verify**:
     Restart the Tangled application. Your new plugin should automatically appear in the API list (`/api/plugins/datasources` or `/api/plugins/visualizers`) and in the generic UI dropdowns.
+
+## 6. Visualizer Plugin Conventions
+
+For the platform's GraphRenderer to work correctly with your plugin,
+your rendered SVG must follow these conventions:
+
+### Required SVG attributes
+
+Add these `data-*` attributes to your root `<svg>` element:
+
+- `data-node-selector` — CSS selector for node groups (e.g. `.node`)
+- `data-link-selector` — CSS selector for edge elements (e.g. `.link`)
+
+### Required CSS classes
+
+- Each node `<g>` element must have a unique `id` matching the node's ID from the Graph model
+- The main visual element of each node (circle, rect, etc.) must have class `node-border` — this enables selection highlight
+
+### Example
+
+```html
+<svg id="svg-{{name}}" data-node-selector=".node" data-link-selector=".link">
+  <g class="node" id="node-1">
+    <circle class="node-border" r="20" />
+    <text>Label</text>
+  </g>
+</svg>
+```

--- a/graph-explorer-django/src/tangled_django/explorer/static/js/birdview.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/birdview.js
@@ -19,6 +19,9 @@ class BirdView {
     // Main view dimensions for viewport calculation
     this.mainViewWidth = 0;
     this.mainViewHeight = 0;
+
+    this.onNodeSelect = null;
+    this.selectedNodeId = null;
   }
 
   /**
@@ -126,7 +129,16 @@ class BirdView {
       .attr("cx", (d) => d.x || 0)
       .attr("cy", (d) => d.y || 0)
       .attr("r", 4 / this.scale)
-      .attr("fill", "#4a90d9");
+      .attr("fill", (d) =>
+        d.id === this.selectedNodeId ? "#ff69b4" : "#4a90d9",
+      ) // ← roze za selektovan
+      .attr("cursor", "pointer")
+      .on("click", (event, d) => {
+        event.preventDefault();
+        this.selectedNodeId = d.id;
+        this._highlightNode(d.id);
+        if (this.onNodeSelect) this.onNodeSelect(d);
+      });
   }
 
   /**
@@ -155,6 +167,18 @@ class BirdView {
       .attr("y", rectY)
       .attr("width", rectWidth)
       .attr("height", rectHeight);
+  }
+
+  selectNodeById(nodeId) {
+    this.selectedNodeId = nodeId;
+    this._highlightNode(nodeId);
+  }
+
+  _highlightNode(nodeId) {
+    if (!this.mainGroup) return;
+    this.mainGroup
+      .selectAll("circle")
+      .attr("fill", (d) => (d.id === nodeId ? "#ff69b4" : "#4a90d9"));
   }
 }
 

--- a/graph-explorer-django/src/tangled_django/explorer/static/js/graph.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/graph.js
@@ -265,7 +265,7 @@ class GraphRenderer {
       .on("click.platform", (event) => {
         const id = d3.select(event.currentTarget).attr("id");
         const node = this._nodeById.get(id);
-        if (node) this._selectNode(node);
+        if (node) this.selectNodeById(node.id);
       })
       .on("mouseover.platform", (event) => {
         const id = d3.select(event.currentTarget).attr("id");
@@ -661,13 +661,48 @@ class GraphRenderer {
   }
 
   _selectNode(node) {
+    if (this.selectedNode) {
+      const prevEl = this.svg
+        ?.node()
+        .querySelector(
+          `${this._nodeSelector}[id="${this.selectedNode.id}"] .node-border`,
+        );
+      if (prevEl) prevEl.style.stroke = "#3a7bc8";
+    }
+
     this.selectedNode = node;
+
+    const el = this.svg
+      ?.node()
+      .querySelector(`${this._nodeSelector}[id="${node.id}"] .node-border`);
+    if (el) el.style.stroke = "#ff69b4";
+
     if (this.onNodeSelect) this.onNodeSelect(node);
   }
 
   selectNodeById(nodeId) {
     const node = this.simulation?.nodes().find((n) => n.id === nodeId);
-    if (node) this._selectNode(node);
+    if (node) {
+      this._selectNode(node);
+      this._zoomToNode(node);
+    }
+  }
+
+  _zoomToNode(node) {
+    if (!this.svg || !this.zoom) return;
+    if (!isFinite(node.x) || !isFinite(node.y)) return;
+
+    const scale = 1.5;
+    const tx = this._w / 2 - node.x * scale;
+    const ty = this._h / 2 - node.y * scale;
+
+    this.svg
+      .transition()
+      .duration(500)
+      .call(
+        this.zoom.transform,
+        d3.zoomIdentity.translate(tx, ty).scale(scale),
+      );
   }
 
   _showTooltip(event, node) {

--- a/graph-explorer-django/src/tangled_django/explorer/static/js/treeview.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/treeview.js
@@ -7,405 +7,474 @@
  */
 
 class TreeView {
-    constructor(containerId) {
-        this.containerId = containerId;
-        this.container = document.getElementById(containerId);
-        this.graphData = null;
-        this.adjacencyMap = new Map();
-        this.expandedNodes = new Set();
-        this.selectedNodeId = null;
-        this.rootId = null;
+  constructor(containerId) {
+    this.containerId = containerId;
+    this.container = document.getElementById(containerId);
+    this.graphData = null;
+    this.adjacencyMap = new Map();
+    this.expandedNodes = new Set();
+    this.selectedNodeId = null;
+    this.rootId = null;
 
-        // Callback for node selection
-        this.onNodeSelect = null;
+    // Callback for node selection
+    this.onNodeSelect = null;
+  }
+
+  /**
+   * Render graph data as a tree
+   * @param {Object} data - Graph data with nodes and edges
+   * @param {string} rootId - Optional root node ID
+   */
+  render(data, rootId = null) {
+    if (!this.container || !data || !data.nodes || data.nodes.length === 0) {
+      if (this.container) {
+        this.container.innerHTML =
+          '<p class="tree-placeholder">No data to display</p>';
+      }
+      return;
     }
 
-    /**
-     * Render graph data as a tree
-     * @param {Object} data - Graph data with nodes and edges
-     * @param {string} rootId - Optional root node ID
-     */
-    render(data, rootId = null) {
-        if (!this.container || !data || !data.nodes || data.nodes.length === 0) {
-            if (this.container) {
-                this.container.innerHTML = '<p class="tree-placeholder">No data to display</p>';
-            }
-            return;
+    this.graphData = data;
+    this._buildAdjacencyMap(data);
+
+    // Choose root: explicit > preferred (no incoming edges) > first node
+    if (rootId && this.adjacencyMap.has(rootId)) {
+      this.rootId = rootId;
+    } else if (!this.rootId || !this.adjacencyMap.has(this.rootId)) {
+      this.rootId = this._findBestRoot(data);
+    }
+
+    this._renderTree();
+  }
+
+  /**
+   * Build adjacency map from graph data
+   */
+  _buildAdjacencyMap(data) {
+    this.adjacencyMap.clear();
+    const incomingCount = new Map();
+
+    data.nodes.forEach((node) => {
+      this.adjacencyMap.set(node.id, { node, children: [] });
+      incomingCount.set(node.id, 0);
+    });
+
+    data.edges.forEach((edge) => {
+      const sourceId =
+        typeof edge.source === "object" ? edge.source.id : edge.source;
+      const targetId =
+        typeof edge.target === "object" ? edge.target.id : edge.target;
+
+      const source = this.adjacencyMap.get(sourceId);
+      if (source && this.adjacencyMap.has(targetId)) {
+        source.children.push(targetId);
+        incomingCount.set(targetId, (incomingCount.get(targetId) || 0) + 1);
+      }
+
+      if (data.directed === false) {
+        const target = this.adjacencyMap.get(targetId);
+        if (target && this.adjacencyMap.has(sourceId)) {
+          target.children.push(sourceId);
         }
+      }
+    });
 
-        this.graphData = data;
-        this._buildAdjacencyMap(data);
+    this._incomingCount = incomingCount;
+  }
 
-        // Choose root: explicit > preferred (no incoming edges) > first node
-        if (rootId && this.adjacencyMap.has(rootId)) {
-            this.rootId = rootId;
-        } else if (!this.rootId || !this.adjacencyMap.has(this.rootId)) {
-            this.rootId = this._findBestRoot(data);
+  /**
+   * Find best root node — prefer nodes with no incoming edges
+   */
+  _findBestRoot(data) {
+    if (this._incomingCount) {
+      for (const [nodeId, count] of this._incomingCount) {
+        if (count === 0) return nodeId;
+      }
+    }
+    return data.nodes[0].id;
+  }
+
+  /**
+   * Render the full tree from root
+   */
+  _renderTree() {
+    this.container.innerHTML = "";
+    const fragment = document.createDocumentFragment();
+    const pathSet = new Set();
+    const rendered = new Set();
+
+    const rootEl = this._createNodeElement(this.rootId, pathSet, 0);
+    if (rootEl) {
+      fragment.appendChild(rootEl);
+      rendered.add(this.rootId);
+    }
+
+    for (const [nodeId] of this.adjacencyMap) {
+      if (!rendered.has(nodeId) && !this._isReachable(this.rootId, nodeId)) {
+        const el = this._createNodeElement(nodeId, new Set(), 0);
+        if (el) {
+          fragment.appendChild(el);
+          rendered.add(nodeId);
         }
+      }
+    }
 
+    this.container.appendChild(fragment);
+  }
+
+  _isReachable(fromId, targetId) {
+    const visited = new Set();
+    const queue = [fromId];
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (current === targetId) return true;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const entry = this.adjacencyMap.get(current);
+      if (entry) entry.children.forEach((c) => queue.push(c));
+    }
+    return false;
+  }
+
+  /**
+   * Create a DOM element for a tree node (lazy — children only built when expanded)
+   */
+  _createNodeElement(nodeId, pathSet, depth) {
+    const entry = this.adjacencyMap.get(nodeId);
+    if (!entry) return null;
+
+    const { node, children } = entry;
+    const isCyclic = pathSet.has(nodeId);
+    const hasChildren = children.length > 0;
+    const isExpanded = this.expandedNodes.has(nodeId);
+    const hasAttributes =
+      node.attributes && Object.keys(node.attributes).length > 0;
+
+    // Create node container
+    const nodeEl = document.createElement("div");
+    nodeEl.className = "tree-node";
+    nodeEl.dataset.nodeId = nodeId;
+    if (depth > 0) nodeEl.dataset.depth = depth;
+
+    // Create header row
+    const header = document.createElement("div");
+    header.className = "tree-node-header";
+    if (this.selectedNodeId === nodeId) header.classList.add("selected");
+
+    // Toggle button
+    const toggle = document.createElement("span");
+    toggle.className = "tree-toggle";
+
+    if (isCyclic) {
+      toggle.innerHTML =
+        '<span class="tree-cycle-icon" title="Cyclic reference">&#x21BA;</span>';
+      toggle.classList.add("cyclic");
+    } else if (hasChildren || hasAttributes) {
+      toggle.textContent = isExpanded ? "\u2212" : "+";
+      toggle.dataset.toggle = nodeId;
+    } else {
+      toggle.innerHTML = "&nbsp;";
+    }
+
+    // Label
+    const label = document.createElement("span");
+    label.className = "tree-label";
+    if (isCyclic) {
+      label.classList.add("tree-label-cyclic");
+    }
+    label.textContent = this._getLabel(node);
+    label.title = nodeId;
+
+    header.appendChild(toggle);
+    header.appendChild(label);
+    nodeEl.appendChild(header);
+
+    // Cyclic reference — clicking navigates to the original occurrence
+    if (isCyclic) {
+      header.addEventListener("click", () => {
+        this._selectAndScrollTo(nodeId);
+      });
+      return nodeEl;
+    }
+
+    // Attach header click for selection
+    header.addEventListener("click", (e) => {
+      if (e.target.closest(".tree-toggle[data-toggle]")) return;
+      this._handleSelect(nodeId, header);
+    });
+
+    // Attach toggle click for expand/collapse
+    if (toggle.dataset.toggle) {
+      toggle.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this._handleToggle(nodeId);
+      });
+    }
+
+    // Render expanded content (attributes + children)
+    if (isExpanded && !isCyclic) {
+      this._renderExpandedContent(
+        nodeEl,
+        nodeId,
+        node,
+        children,
+        hasAttributes,
+        pathSet,
+        depth,
+      );
+    }
+
+    return nodeEl;
+  }
+
+  /**
+   * Render attributes and children into an expanded node
+   */
+  _renderExpandedContent(
+    nodeEl,
+    nodeId,
+    node,
+    children,
+    hasAttributes,
+    pathSet,
+    depth,
+  ) {
+    // Attribute list
+    if (hasAttributes) {
+      const attrContainer = document.createElement("div");
+      attrContainer.className = "tree-attributes";
+
+      Object.entries(node.attributes).forEach(([key, attr]) => {
+        const row = document.createElement("div");
+        row.className = "tree-attr-row";
+
+        const keySpan = document.createElement("span");
+        keySpan.className = "tree-attr-key";
+        keySpan.textContent = key;
+
+        const valSpan = document.createElement("span");
+        valSpan.className = "tree-attr-value";
+        const { display, typeClass } = this._formatAttrValue(attr);
+        valSpan.textContent = display;
+        if (typeClass) valSpan.classList.add(typeClass);
+
+        row.appendChild(keySpan);
+        row.appendChild(valSpan);
+        attrContainer.appendChild(row);
+      });
+
+      nodeEl.appendChild(attrContainer);
+    }
+
+    // Children
+    if (children.length > 0) {
+      const childrenContainer = document.createElement("div");
+      childrenContainer.className = "tree-children";
+
+      pathSet.add(nodeId);
+      children.forEach((childId) => {
+        const childEl = this._createNodeElement(childId, pathSet, depth + 1);
+        if (childEl) childrenContainer.appendChild(childEl);
+      });
+      pathSet.delete(nodeId);
+
+      nodeEl.appendChild(childrenContainer);
+    }
+  }
+
+  /**
+   * Handle toggle expand/collapse
+   */
+  _handleToggle(nodeId) {
+    if (this.expandedNodes.has(nodeId)) {
+      this.expandedNodes.delete(nodeId);
+    } else {
+      this.expandedNodes.add(nodeId);
+    }
+
+    // Full re-render from root to guarantee correct cycle detection
+    // (subtree re-render would lose ancestor context for cycle paths)
+    this._renderTree();
+  }
+
+  /**
+   * Handle node selection
+   */
+  _handleSelect(nodeId, headerEl) {
+    // Remove previous selection
+    this.container
+      .querySelectorAll(".tree-node-header.selected")
+      .forEach((h) => {
+        h.classList.remove("selected");
+      });
+    headerEl.classList.add("selected");
+    this.selectedNodeId = nodeId;
+
+    if (this.onNodeSelect) {
+      const node = this.graphData.nodes.find((n) => n.id === nodeId);
+      if (node) this.onNodeSelect(node);
+    }
+  }
+
+  /**
+   * Select and scroll to a node — used for cyclic reference clicks
+   */
+  _selectAndScrollTo(nodeId) {
+    // Find the first non-cyclic occurrence of this node
+    const allMatches = this.container.querySelectorAll(
+      `.tree-node[data-node-id="${CSS.escape(nodeId)}"]`,
+    );
+    for (const el of allMatches) {
+      if (el.querySelector(".tree-cycle-icon")) continue;
+      const header = el.querySelector(".tree-node-header");
+      if (!header) continue;
+      this._handleSelect(nodeId, header);
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
+  }
+
+  /**
+   * Select node by ID — cross-view sync with auto-expand path
+   * @param {string} nodeId
+   */
+  selectNodeById(nodeId) {
+    if (!this.graphData || !this.adjacencyMap.has(nodeId)) return;
+
+    this.selectedNodeId = nodeId;
+
+    // Find path from root to target using BFS
+    const path = this._findPathBFS(this.rootId, nodeId);
+    if (path) {
+      // Expand all ancestors (not the target itself unless it was already expanded)
+      let needsRerender = false;
+      for (let i = 0; i < path.length - 1; i++) {
+        if (!this.expandedNodes.has(path[i])) {
+          this.expandedNodes.add(path[i]);
+          needsRerender = true;
+        }
+      }
+      if (needsRerender) {
         this._renderTree();
+      }
     }
 
-    /**
-     * Build adjacency map from graph data
-     */
-    _buildAdjacencyMap(data) {
-        this.adjacencyMap.clear();
-        const incomingCount = new Map();
+    // Highlight and scroll
+    this.container
+      .querySelectorAll(".tree-node-header.selected")
+      .forEach((h) => {
+        h.classList.remove("selected");
+      });
 
-        data.nodes.forEach(node => {
-            this.adjacencyMap.set(node.id, { node, children: [] });
-            incomingCount.set(node.id, 0);
-        });
+    const target = this.container.querySelector(
+      `.tree-node[data-node-id="${CSS.escape(nodeId)}"] > .tree-node-header`,
+    );
+    if (target) {
+      target.classList.add("selected");
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }
 
-        data.edges.forEach(edge => {
-            const sourceId = typeof edge.source === 'object' ? edge.source.id : edge.source;
-            const targetId = typeof edge.target === 'object' ? edge.target.id : edge.target;
+  /**
+   * BFS to find path from source to target using parent map
+   * @returns {Array|null} Array of node IDs from source to target, or null
+   */
+  _findPathBFS(sourceId, targetId) {
+    if (sourceId === targetId) return [sourceId];
 
-            const source = this.adjacencyMap.get(sourceId);
-            if (source && this.adjacencyMap.has(targetId)) {
-                source.children.push(targetId);
-                incomingCount.set(targetId, (incomingCount.get(targetId) || 0) + 1);
-            }
+    const visited = new Set([sourceId]);
+    const parent = new Map();
+    const queue = [sourceId];
 
-            if (data.directed === false) {
-                const target = this.adjacencyMap.get(targetId);
-                if (target && this.adjacencyMap.has(sourceId)) {
-                    target.children.push(sourceId);
-                }
-            }
-        });
+    while (queue.length > 0) {
+      const current = queue.shift();
+      const entry = this.adjacencyMap.get(current);
+      if (!entry) continue;
 
-        this._incomingCount = incomingCount;
+      for (const childId of entry.children) {
+        if (visited.has(childId)) continue;
+        parent.set(childId, current);
+        if (childId === targetId) {
+          // Reconstruct path
+          const path = [targetId];
+          let node = targetId;
+          while (node !== sourceId) {
+            node = parent.get(node);
+            path.unshift(node);
+          }
+          return path;
+        }
+        visited.add(childId);
+        queue.push(childId);
+      }
     }
 
-    /**
-     * Find best root node — prefer nodes with no incoming edges
-     */
-    _findBestRoot(data) {
-        if (this._incomingCount) {
-            for (const [nodeId, count] of this._incomingCount) {
-                if (count === 0) return nodeId;
-            }
+    return null;
+  }
+
+  /**
+   * Get display label for a node
+   */
+  _getLabel(node) {
+    // Prefer common name-like attributes
+    if (node.attributes) {
+      for (const key of ["name", "label", "title", "first"]) {
+        const attr = node.attributes[key];
+        if (attr) {
+          const val = typeof attr === "object" ? attr.value : attr;
+          if (val != null && val !== "") return String(val);
         }
-        return data.nodes[0].id;
+      }
+    }
+    if (node.label) return node.label;
+    return String(node.id);
+  }
+
+  /**
+   * Format attribute value for display with type awareness
+   */
+  _formatAttrValue(attr) {
+    if (attr === null || attr === undefined) {
+      return { display: "null", typeClass: "attr-type-null" };
     }
 
-    /**
-     * Render the full tree from root
-     */
-    _renderTree() {
-        this.container.innerHTML = '';
+    const value =
+      typeof attr === "object" && attr.value !== undefined ? attr.value : attr;
+    const type =
+      typeof attr === "object" && attr.type ? attr.type : typeof value;
 
-        const fragment = document.createDocumentFragment();
-        const pathSet = new Set();
-        const rootEl = this._createNodeElement(this.rootId, pathSet, 0);
-        if (rootEl) fragment.appendChild(rootEl);
-
-        this.container.appendChild(fragment);
+    switch (type) {
+      case "number":
+      case "integer":
+      case "float":
+        return { display: String(value), typeClass: "attr-type-number" };
+      case "boolean":
+        return { display: String(value), typeClass: "attr-type-boolean" };
+      case "date":
+      case "datetime": {
+        const d = new Date(value);
+        const display = isNaN(d.getTime())
+          ? String(value)
+          : d.toLocaleDateString();
+        return { display, typeClass: "attr-type-date" };
+      }
+      case "string":
+      default:
+        return { display: `"${value}"`, typeClass: "attr-type-string" };
     }
+  }
 
-    /**
-     * Create a DOM element for a tree node (lazy — children only built when expanded)
-     */
-    _createNodeElement(nodeId, pathSet, depth) {
-        const entry = this.adjacencyMap.get(nodeId);
-        if (!entry) return null;
-
-        const { node, children } = entry;
-        const isCyclic = pathSet.has(nodeId);
-        const hasChildren = children.length > 0;
-        const isExpanded = this.expandedNodes.has(nodeId);
-        const hasAttributes = node.attributes && Object.keys(node.attributes).length > 0;
-
-        // Create node container
-        const nodeEl = document.createElement('div');
-        nodeEl.className = 'tree-node';
-        nodeEl.dataset.nodeId = nodeId;
-        if (depth > 0) nodeEl.dataset.depth = depth;
-
-        // Create header row
-        const header = document.createElement('div');
-        header.className = 'tree-node-header';
-        if (this.selectedNodeId === nodeId) header.classList.add('selected');
-
-        // Toggle button
-        const toggle = document.createElement('span');
-        toggle.className = 'tree-toggle';
-
-        if (isCyclic) {
-            toggle.innerHTML = '<span class="tree-cycle-icon" title="Cyclic reference">&#x21BA;</span>';
-            toggle.classList.add('cyclic');
-        } else if (hasChildren || hasAttributes) {
-            toggle.textContent = isExpanded ? '\u2212' : '+';
-            toggle.dataset.toggle = nodeId;
-        } else {
-            toggle.innerHTML = '&nbsp;';
-        }
-
-        // Label
-        const label = document.createElement('span');
-        label.className = 'tree-label';
-        if (isCyclic) {
-            label.classList.add('tree-label-cyclic');
-        }
-        label.textContent = this._getLabel(node);
-        label.title = nodeId;
-
-        header.appendChild(toggle);
-        header.appendChild(label);
-        nodeEl.appendChild(header);
-
-        // Cyclic reference — clicking navigates to the original occurrence
-        if (isCyclic) {
-            header.addEventListener('click', () => {
-                this._selectAndScrollTo(nodeId);
-            });
-            return nodeEl;
-        }
-
-        // Attach header click for selection
-        header.addEventListener('click', (e) => {
-            if (e.target.closest('.tree-toggle[data-toggle]')) return;
-            this._handleSelect(nodeId, header);
-        });
-
-        // Attach toggle click for expand/collapse
-        if (toggle.dataset.toggle) {
-            toggle.addEventListener('click', (e) => {
-                e.stopPropagation();
-                this._handleToggle(nodeId);
-            });
-        }
-
-        // Render expanded content (attributes + children)
-        if (isExpanded && !isCyclic) {
-            this._renderExpandedContent(nodeEl, nodeId, node, children, hasAttributes, pathSet, depth);
-        }
-
-        return nodeEl;
+  clear() {
+    this.graphData = null;
+    this.adjacencyMap.clear();
+    this.expandedNodes.clear();
+    this.selectedNodeId = null;
+    this.rootId = null;
+    if (this.container) {
+      this.container.innerHTML =
+        '<p class="tree-placeholder">Load data to see tree view</p>';
     }
-
-    /**
-     * Render attributes and children into an expanded node
-     */
-    _renderExpandedContent(nodeEl, nodeId, node, children, hasAttributes, pathSet, depth) {
-        // Attribute list
-        if (hasAttributes) {
-            const attrContainer = document.createElement('div');
-            attrContainer.className = 'tree-attributes';
-
-            Object.entries(node.attributes).forEach(([key, attr]) => {
-                const row = document.createElement('div');
-                row.className = 'tree-attr-row';
-
-                const keySpan = document.createElement('span');
-                keySpan.className = 'tree-attr-key';
-                keySpan.textContent = key;
-
-                const valSpan = document.createElement('span');
-                valSpan.className = 'tree-attr-value';
-                const { display, typeClass } = this._formatAttrValue(attr);
-                valSpan.textContent = display;
-                if (typeClass) valSpan.classList.add(typeClass);
-
-                row.appendChild(keySpan);
-                row.appendChild(valSpan);
-                attrContainer.appendChild(row);
-            });
-
-            nodeEl.appendChild(attrContainer);
-        }
-
-        // Children
-        if (children.length > 0) {
-            const childrenContainer = document.createElement('div');
-            childrenContainer.className = 'tree-children';
-
-            pathSet.add(nodeId);
-            children.forEach(childId => {
-                const childEl = this._createNodeElement(childId, pathSet, depth + 1);
-                if (childEl) childrenContainer.appendChild(childEl);
-            });
-            pathSet.delete(nodeId);
-
-            nodeEl.appendChild(childrenContainer);
-        }
-    }
-
-    /**
-     * Handle toggle expand/collapse
-     */
-    _handleToggle(nodeId) {
-        if (this.expandedNodes.has(nodeId)) {
-            this.expandedNodes.delete(nodeId);
-        } else {
-            this.expandedNodes.add(nodeId);
-        }
-
-        // Full re-render from root to guarantee correct cycle detection
-        // (subtree re-render would lose ancestor context for cycle paths)
-        this._renderTree();
-    }
-
-    /**
-     * Handle node selection
-     */
-    _handleSelect(nodeId, headerEl) {
-        // Remove previous selection
-        this.container.querySelectorAll('.tree-node-header.selected').forEach(h => {
-            h.classList.remove('selected');
-        });
-        headerEl.classList.add('selected');
-        this.selectedNodeId = nodeId;
-
-        if (this.onNodeSelect) {
-            const node = this.graphData.nodes.find(n => n.id === nodeId);
-            if (node) this.onNodeSelect(node);
-        }
-    }
-
-    /**
-     * Select and scroll to a node — used for cyclic reference clicks
-     */
-    _selectAndScrollTo(nodeId) {
-        // Find the first non-cyclic occurrence of this node
-        const allMatches = this.container.querySelectorAll(
-            `.tree-node[data-node-id="${CSS.escape(nodeId)}"]`
-        );
-        for (const el of allMatches) {
-            if (el.querySelector('.tree-cycle-icon')) continue;
-            const header = el.querySelector('.tree-node-header');
-            if (!header) continue;
-            this._handleSelect(nodeId, header);
-            el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            return;
-        }
-    }
-
-    /**
-     * Select node by ID — cross-view sync with auto-expand path
-     * @param {string} nodeId
-     */
-    selectNodeById(nodeId) {
-        if (!this.graphData || !this.adjacencyMap.has(nodeId)) return;
-
-        this.selectedNodeId = nodeId;
-
-        // Find path from root to target using BFS
-        const path = this._findPathBFS(this.rootId, nodeId);
-        if (path) {
-            // Expand all ancestors (not the target itself unless it was already expanded)
-            let needsRerender = false;
-            for (let i = 0; i < path.length - 1; i++) {
-                if (!this.expandedNodes.has(path[i])) {
-                    this.expandedNodes.add(path[i]);
-                    needsRerender = true;
-                }
-            }
-            if (needsRerender) {
-                this._renderTree();
-            }
-        }
-
-        // Highlight and scroll
-        this.container.querySelectorAll('.tree-node-header.selected').forEach(h => {
-            h.classList.remove('selected');
-        });
-
-        const target = this.container.querySelector(
-            `.tree-node[data-node-id="${CSS.escape(nodeId)}"] > .tree-node-header`
-        );
-        if (target) {
-            target.classList.add('selected');
-            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-    }
-
-    /**
-     * BFS to find path from source to target using parent map
-     * @returns {Array|null} Array of node IDs from source to target, or null
-     */
-    _findPathBFS(sourceId, targetId) {
-        if (sourceId === targetId) return [sourceId];
-
-        const visited = new Set([sourceId]);
-        const parent = new Map();
-        const queue = [sourceId];
-
-        while (queue.length > 0) {
-            const current = queue.shift();
-            const entry = this.adjacencyMap.get(current);
-            if (!entry) continue;
-
-            for (const childId of entry.children) {
-                if (visited.has(childId)) continue;
-                parent.set(childId, current);
-                if (childId === targetId) {
-                    // Reconstruct path
-                    const path = [targetId];
-                    let node = targetId;
-                    while (node !== sourceId) {
-                        node = parent.get(node);
-                        path.unshift(node);
-                    }
-                    return path;
-                }
-                visited.add(childId);
-                queue.push(childId);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Get display label for a node
-     */
-    _getLabel(node) {
-        // Prefer common name-like attributes
-        if (node.attributes) {
-            for (const key of ['name', 'label', 'title', 'first']) {
-                const attr = node.attributes[key];
-                if (attr) {
-                    const val = typeof attr === 'object' ? attr.value : attr;
-                    if (val != null && val !== '') return String(val);
-                }
-            }
-        }
-        if (node.label) return node.label;
-        return String(node.id);
-    }
-
-    /**
-     * Format attribute value for display with type awareness
-     */
-    _formatAttrValue(attr) {
-        if (attr === null || attr === undefined) {
-            return { display: 'null', typeClass: 'attr-type-null' };
-        }
-
-        const value = typeof attr === 'object' && attr.value !== undefined ? attr.value : attr;
-        const type = typeof attr === 'object' && attr.type ? attr.type : typeof value;
-
-        switch (type) {
-            case 'number':
-            case 'integer':
-            case 'float':
-                return { display: String(value), typeClass: 'attr-type-number' };
-            case 'boolean':
-                return { display: String(value), typeClass: 'attr-type-boolean' };
-            case 'date':
-            case 'datetime': {
-                const d = new Date(value);
-                const display = isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
-                return { display, typeClass: 'attr-type-date' };
-            }
-            case 'string':
-            default:
-                return { display: `"${value}"`, typeClass: 'attr-type-string' };
-        }
-    }
+  }
 }
 
 // Export for use in workspace.js

--- a/graph-explorer-django/src/tangled_django/explorer/static/js/workspace.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/workspace.js
@@ -19,6 +19,7 @@ class WorkspaceController {
     this._setupEventHandlers();
     this._setupViewSynchronization();
     this._loadDataSources();
+    this._isCleared = false;
   }
 
   /**
@@ -68,11 +69,38 @@ class WorkspaceController {
 
     // CLI form
     const cliForm = document.getElementById("cli-form");
+    const cliInput = document.getElementById("cli-input");
+    this._cliHistory = [];
+    this._cliHistoryIndex = -1;
+
+    cliInput?.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (this._cliHistoryIndex < this._cliHistory.length - 1) {
+          this._cliHistoryIndex++;
+          cliInput.value = this._cliHistory[this._cliHistoryIndex];
+        }
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (this._cliHistoryIndex > 0) {
+          this._cliHistoryIndex--;
+          cliInput.value = this._cliHistory[this._cliHistoryIndex];
+        } else {
+          this._cliHistoryIndex = -1;
+          cliInput.value = "";
+        }
+      }
+    });
+
     cliForm?.addEventListener("submit", (e) => {
       e.preventDefault();
-      const command = document.getElementById("cli-input").value;
+      const command = cliInput.value;
+      if (command) {
+        this._cliHistory.unshift(command);
+        this._cliHistoryIndex = -1;
+      }
       this._handleCliCommand(command);
-      document.getElementById("cli-input").value = "";
+      cliInput.value = "";
     });
   }
 
@@ -83,11 +111,17 @@ class WorkspaceController {
     // Sync node selection across views
     this.graphRenderer.onNodeSelect = (node) => {
       this.treeView.selectNodeById(node.id);
-      // Bird view doesn't need selection sync
+      this.birdView.selectNodeById(node.id);
     };
 
     this.treeView.onNodeSelect = (node) => {
       this.graphRenderer.selectNodeById(node.id);
+      this.birdView.selectNodeById(node.id);
+    };
+
+    this.birdView.onNodeSelect = (node) => {
+      this.graphRenderer.selectNodeById(node.id);
+      this.treeView.selectNodeById(node.id);
     };
 
     // Sync viewport changes to bird view
@@ -247,22 +281,33 @@ class WorkspaceController {
    */
   async _handleSearch(query) {
     if (!query) return;
-
     try {
       const result = await api.post(
         `/api/workspace/${this.workspaceId}/search`,
         { query },
       );
-
       if (result.error) {
         showNotification(result.error, "error");
       } else {
         showNotification(`Found ${result.node_count} nodes`, "info");
-        await this._refreshVisualization();
+        await this._refreshData();
       }
     } catch (error) {
       showNotification("Search failed", "error");
-      console.error(error);
+    }
+  }
+
+  async _refreshData() {
+    try {
+      const graphData = await api.get(
+        `/api/workspace/${this.workspaceId}/graph`,
+      );
+      this.graphData = graphData;
+      this.graphRenderer.update(graphData);
+      this.birdView.render(graphData);
+      this.treeView.render(graphData);
+    } catch (error) {
+      console.error("Failed to refresh data:", error);
     }
   }
 
@@ -282,7 +327,7 @@ class WorkspaceController {
         showNotification(result.error, "error");
       } else {
         showNotification(`Filtered to ${result.node_count} nodes`, "info");
-        await this._refreshVisualization();
+        await this._refreshData();
       }
     } catch (error) {
       showNotification("Filter failed", "error");
@@ -298,7 +343,7 @@ class WorkspaceController {
       await api.post(`/api/workspace/${this.workspaceId}/reset`);
       document.getElementById("search-input").value = "";
       document.getElementById("filter-input").value = "";
-      await this._refreshVisualization();
+      await this._refreshData();
       showNotification("Reset to original graph", "info");
     } catch (error) {
       showNotification("Reset failed", "error");
@@ -324,14 +369,45 @@ class WorkspaceController {
         output.innerHTML += `<div class="cli-error">${result.error}</div>`;
       } else {
         output.innerHTML += `<div class="cli-result">${result.result || "OK"}</div>`;
-        await this._refreshVisualization();
+
+        if (result.changed) {
+          const clearRe = /^clear\b/i;
+          const structuralRe = /^(filter|search|reset)\b/i;
+
+          if (clearRe.test(command.trim())) {
+            this._clearViews();
+          } else if (structuralRe.test(command.trim())) {
+            this._isCleared = false;
+            await this._refreshVisualization();
+          } else {
+            if (!this._isCleared) {
+              await this._refreshData();
+            }
+          }
+        }
       }
     } catch (error) {
       output.innerHTML += `<div class="cli-error">Command failed</div>`;
     }
 
-    // Scroll to bottom
     output.scrollTop = output.scrollHeight;
+  }
+
+  _clearViews() {
+    this._isCleared = true;
+    this.graphData = null;
+    const mainContainer = document.getElementById("main-graph-container");
+    mainContainer.innerHTML =
+      '<p class="placeholder">Load data to visualize graph</p>';
+    this.birdView.init();
+    this.treeView.clear?.();
+
+    const dataSourceSelect = document.getElementById("data-source-select");
+    if (dataSourceSelect) dataSourceSelect.value = "";
+    document.getElementById("plugin-params").innerHTML = "";
+
+    document.getElementById("search-input").value = "";
+    document.getElementById("filter-input").value = "";
   }
 }
 

--- a/graph-explorer/src/tangled_graph_explorer/static/css/workspace.css
+++ b/graph-explorer/src/tangled_graph_explorer/static/css/workspace.css
@@ -4,460 +4,517 @@
  */
 
 .workspace-page {
-    display: grid;
-    gap: 0.75rem;
-    height: calc(100vh - 3.5rem);
-    grid-template-columns: 260px 280px 1fr;
-    grid-template-rows: 1fr 280px;
-    grid-template-areas:
-        "controls tree main"
-        "controls bird cli";
+  display: grid;
+  gap: 0.75rem;
+  height: calc(100vh - 5rem);
+  grid-template-columns: 260px 280px 1fr;
+  grid-template-rows: 1fr 180px;
+  grid-template-areas:
+    "controls tree main"
+    "controls bird cli";
 }
 
 /* ── Control Panel ── */
 .control-panel {
-    grid-area: controls;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    overflow-y: auto;
-    padding-right: 0.25rem;
+  grid-area: controls;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
-.control-panel section { border-radius: 16px; padding: 1rem; }
+.control-panel section {
+  border-radius: 16px;
+  padding: 1rem;
+}
 
 .control-panel h3 {
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #40C9FF;
-    margin-bottom: 0.75rem;
-    font-family: 'Quicksand', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #40c9ff;
+  margin-bottom: 0.75rem;
+  font-family: "Quicksand", sans-serif;
 }
 
 .control-panel label {
-    display: block;
-    font-size: 0.78rem;
-    color: rgba(27, 42, 92, 0.6);
-    margin-bottom: 0.3rem;
-    font-family: 'Quicksand', sans-serif;
-    font-weight: 600;
+  display: block;
+  font-size: 0.78rem;
+  color: rgba(27, 42, 92, 0.6);
+  margin-bottom: 0.3rem;
+  font-family: "Quicksand", sans-serif;
+  font-weight: 600;
 }
 
-.param-input { margin-bottom: 0.5rem; }
+.param-input {
+  margin-bottom: 0.5rem;
+}
 
 /* ── Tree View ── */
 .tree-view {
-    grid-area: tree;
-    border-radius: 16px;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
+  grid-area: tree;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .tree-view h3 {
-    padding: 0.85rem 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #40C9FF;
-    font-family: 'Quicksand', sans-serif;
-    flex-shrink: 0;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #40c9ff;
+  font-family: "Quicksand", sans-serif;
+  flex-shrink: 0;
 }
 
 #tree-container {
-    flex: 1;
-    overflow: auto;
-    padding: 0.5rem;
-    scroll-behavior: smooth;
+  flex: 1;
+  overflow: auto;
+  padding: 0.5rem;
+  scroll-behavior: smooth;
 }
 
 .tree-placeholder {
-    color: rgba(27, 42, 92, 0.35);
-    font-family: 'Quicksand', sans-serif;
-    font-size: 0.82rem;
-    text-align: center;
-    padding: 2rem 1rem;
+  color: rgba(27, 42, 92, 0.35);
+  font-family: "Quicksand", sans-serif;
+  font-size: 0.82rem;
+  text-align: center;
+  padding: 2rem 1rem;
 }
 
-.tree-node { padding: 1px 0; }
+.tree-node {
+  padding: 1px 0;
+}
 
 .tree-node-header {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    padding: 0.3rem 0.5rem;
-    border-radius: 8px;
-    border: 1px solid transparent;
-    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-    font-family: 'Quicksand', sans-serif;
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #1B2A5C;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 0.3rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  font-family: "Quicksand", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #1b2a5c;
 }
 
 .tree-node-header:hover {
-    background: rgba(64, 201, 255, 0.1);
-    box-shadow: 0 0 8px rgba(64, 201, 255, 0.08);
+  background: rgba(64, 201, 255, 0.1);
+  box-shadow: 0 0 8px rgba(64, 201, 255, 0.08);
 }
 
 .tree-node-header.selected {
-    background: rgba(255, 107, 157, 0.12);
-    border-color: rgba(255, 107, 157, 0.3);
-    box-shadow: 0 0 10px rgba(255, 107, 157, 0.1);
+  background: rgba(255, 107, 157, 0.12);
+  border-color: rgba(255, 107, 157, 0.3);
+  box-shadow: 0 0 10px rgba(255, 107, 157, 0.1);
 }
 
 .tree-toggle {
-    width: 20px;
-    height: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.8rem;
-    font-weight: 700;
-    color: #40C9FF;
-    flex-shrink: 0;
-    user-select: none;
-    border-radius: 6px;
-    transition: background 0.15s ease, box-shadow 0.15s ease;
-    margin-right: 4px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #40c9ff;
+  flex-shrink: 0;
+  user-select: none;
+  border-radius: 6px;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease;
+  margin-right: 4px;
 }
 
 .tree-toggle[data-toggle]:hover {
-    background: rgba(64, 201, 255, 0.15);
-    box-shadow: 0 0 6px rgba(64, 201, 255, 0.2);
+  background: rgba(64, 201, 255, 0.15);
+  box-shadow: 0 0 6px rgba(64, 201, 255, 0.2);
 }
 
 .tree-toggle.cyclic {
-    color: #E8960C;
+  color: #e8960c;
 }
 
 .tree-cycle-icon {
-    font-size: 0.9rem;
-    line-height: 1;
+  font-size: 0.9rem;
+  line-height: 1;
 }
 
 .tree-label {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tree-label-cyclic {
-    color: rgba(27, 42, 92, 0.45);
-    font-style: italic;
+  color: rgba(27, 42, 92, 0.45);
+  font-style: italic;
 }
 
 /* Connector lines */
 .tree-children {
-    margin-left: 10px;
-    padding-left: 12px;
-    position: relative;
-    border-left: 1px solid rgba(64, 201, 255, 0.2);
+  margin-left: 10px;
+  padding-left: 12px;
+  position: relative;
+  border-left: 1px solid rgba(64, 201, 255, 0.2);
 }
 
 .tree-children > .tree-node {
-    position: relative;
+  position: relative;
 }
 
 .tree-children > .tree-node::before {
-    content: '';
-    position: absolute;
-    top: 12px;
-    left: -12px;
-    width: 10px;
-    height: 0;
-    border-top: 1px solid rgba(64, 201, 255, 0.2);
+  content: "";
+  position: absolute;
+  top: 12px;
+  left: -12px;
+  width: 10px;
+  height: 0;
+  border-top: 1px solid rgba(64, 201, 255, 0.2);
 }
 
 /* Attribute rows */
 .tree-attributes {
-    margin-left: 24px;
-    margin-top: 2px;
-    margin-bottom: 4px;
-    padding: 4px 0;
-    border-left: 1px dashed rgba(64, 201, 255, 0.12);
-    padding-left: 10px;
+  margin-left: 24px;
+  margin-top: 2px;
+  margin-bottom: 4px;
+  padding: 4px 0;
+  border-left: 1px dashed rgba(64, 201, 255, 0.12);
+  padding-left: 10px;
 }
 
 .tree-attr-row {
-    display: flex;
-    align-items: baseline;
-    gap: 0.5rem;
-    padding: 1px 6px;
-    border-radius: 4px;
-    font-size: 0.72rem;
-    line-height: 1.6;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  line-height: 1.6;
 }
 
 .tree-attr-row:nth-child(even) {
-    background: rgba(64, 201, 255, 0.04);
+  background: rgba(64, 201, 255, 0.04);
 }
 
 .tree-attr-key {
-    color: rgba(27, 42, 92, 0.5);
-    font-family: 'Quicksand', sans-serif;
-    font-weight: 600;
-    flex-shrink: 0;
+  color: rgba(27, 42, 92, 0.5);
+  font-family: "Quicksand", sans-serif;
+  font-weight: 600;
+  flex-shrink: 0;
 }
 
 .tree-attr-key::after {
-    content: ':';
+  content: ":";
 }
 
 .tree-attr-value {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.7rem;
-    color: #1B2A5C;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  color: #1b2a5c;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.attr-type-string { color: #2E8B57; }
-.attr-type-number { color: #4a90d9; }
-.attr-type-boolean { color: #9B59B6; }
-.attr-type-date { color: #E8960C; }
-.attr-type-null { color: rgba(27, 42, 92, 0.3); font-style: italic; }
+.attr-type-string {
+  color: #2e8b57;
+}
+.attr-type-number {
+  color: #4a90d9;
+}
+.attr-type-boolean {
+  color: #9b59b6;
+}
+.attr-type-date {
+  color: #e8960c;
+}
+.attr-type-null {
+  color: rgba(27, 42, 92, 0.3);
+  font-style: italic;
+}
 
 /* ── Main View ── */
 .main-view {
-    grid-area: main;
-    border-radius: 16px;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    min-width: 0;
+  grid-area: main;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
 }
 
 .main-view h3 {
-    padding: 0.85rem 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #40C9FF;
-    font-family: 'Quicksand', sans-serif;
-    flex-shrink: 0;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #40c9ff;
+  font-family: "Quicksand", sans-serif;
+  flex-shrink: 0;
 }
 
 #main-graph-container {
-    flex: 1;
-    position: relative;
-    overflow: hidden;
+  flex: 1;
+  position: relative;
+  overflow: hidden;
 }
 
-#main-graph-container svg { width: 100%; height: 100%; }
+#main-graph-container svg {
+  width: 100%;
+  height: 100%;
+}
 
 /* ── Bird View ── */
 .bird-view {
-    grid-area: bird;
-    border-radius: 16px;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
+  grid-area: bird;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .bird-view h3 {
-    padding: 0.65rem 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #40C9FF;
-    font-family: 'Quicksand', sans-serif;
-    flex-shrink: 0;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #40c9ff;
+  font-family: "Quicksand", sans-serif;
+  flex-shrink: 0;
 }
 
 #bird-container {
-    flex: 1;
-    position: relative;
-    background: rgba(64, 201, 255, 0.03);
+  flex: 1;
+  position: relative;
+  background: rgba(64, 201, 255, 0.03);
 }
 
-#bird-container svg { width: 100%; height: 100%; }
+#bird-container svg {
+  width: 100%;
+  height: 100%;
+}
 
 #viewport-rect {
-    position: absolute;
-    border: 1.5px solid #40C9FF;
-    background-color: rgba(64, 201, 255, 0.06);
-    pointer-events: none;
-    border-radius: 2px;
+  position: absolute;
+  border: 1.5px solid #40c9ff;
+  background-color: rgba(64, 201, 255, 0.06);
+  pointer-events: none;
+  border-radius: 2px;
 }
 
 /* ── CLI Section ── */
 .cli-section {
-    grid-area: cli;
-    border-radius: 16px;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    min-width: 0;
+  grid-area: cli;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
 }
 
 .cli-section h3 {
-    padding: 0.65rem 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: rgba(64, 201, 255, 0.7);
-    font-family: 'Quicksand', sans-serif;
-    flex-shrink: 0;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(64, 201, 255, 0.7);
+  font-family: "Quicksand", sans-serif;
+  flex-shrink: 0;
 }
 
 #cli-container {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    background: rgba(10, 20, 45, 0.12);
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.8rem;
-    border-radius: 0 0 16px 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: rgba(10, 20, 45, 0.12);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  border-radius: 0 0 16px 16px;
+  overflow: hidden;
+  min-height: 0;
 }
 
 #cli-output {
-    flex: 1;
-    padding: 0.6rem 0.8rem;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    color: rgba(15, 30, 60, 0.65);
-    line-height: 1.5;
+  flex: 1;
+  padding: 0.6rem 0.8rem;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  color: rgba(15, 30, 60, 0.65);
+  line-height: 1.5;
 }
 
-.cli-command { color: #40C9FF; }
-.cli-result { color: #34B88C; }
-.cli-error { color: #FF6B9D; }
+.cli-command {
+  color: #40c9ff;
+}
+.cli-result {
+  color: #34b88c;
+}
+.cli-error {
+  color: #ff6b9d;
+}
 
 #cli-form {
-    display: flex;
-    align-items: center;
-    padding: 0.5rem 0.8rem;
-    border-top: 1px solid rgba(64, 201, 255, 0.1);
-    gap: 0.4rem;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.8rem;
+  border-top: 1px solid rgba(64, 201, 255, 0.1);
+  gap: 0.4rem;
 }
 
 #cli-form .prompt {
-    color: #FF6B9D;
-    font-weight: 600;
-    user-select: none;
+  color: #ff6b9d;
+  font-weight: 600;
+  user-select: none;
 }
 
 #cli-input {
-    flex: 1;
-    background: transparent;
-    border: none;
-    color: #1B2A5C;
-    font-family: inherit;
-    font-size: inherit;
-    outline: none;
-    padding: 0.25rem 0;
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #1b2a5c;
+  font-family: inherit;
+  font-size: inherit;
+  outline: none;
+  padding: 0.25rem 0;
 }
 
-#cli-input::placeholder { color: rgba(27, 42, 92, 0.25); }
+#cli-input::placeholder {
+  color: rgba(27, 42, 92, 0.25);
+}
 
 /* ── Mobile Sidebar ── */
 .sidebar-toggle {
-    display: none;
-    position: fixed;
-    bottom: 1.25rem;
-    left: 1.25rem;
-    z-index: 100;
-    width: 48px; height: 48px;
-    border-radius: 14px;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    color: #1B2A5C;
+  display: none;
+  position: fixed;
+  bottom: 1.25rem;
+  left: 1.25rem;
+  z-index: 100;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #1b2a5c;
 }
 
 .sidebar-overlay {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(64, 201, 255, 0.15);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-    z-index: 49;
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(64, 201, 255, 0.15);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 49;
 }
 
 /* ── Responsive ── */
 @media (max-width: 1200px) {
-    .workspace-page {
-        grid-template-columns: 240px 1fr;
-        grid-template-rows: 1fr 1fr 240px;
-        grid-template-areas:
-            "controls main"
-            "controls tree"
-            "bird     cli";
-    }
+  .workspace-page {
+    grid-template-columns: 240px 1fr;
+    grid-template-rows: 1fr 1fr 180px;
+    grid-template-areas:
+      "controls main"
+      "controls tree"
+      "bird     cli";
+  }
 }
 
 @media (max-width: 900px) {
-    .workspace-page {
-        grid-template-columns: 1fr 1fr;
-        grid-template-rows: auto 1fr 260px 200px;
-        grid-template-areas:
-            "controls controls"
-            "main     main"
-            "tree     bird"
-            "cli      cli";
-        height: auto;
-        min-height: calc(100vh - 3.5rem);
-    }
+  .workspace-page {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto 1fr 260px 200px;
+    grid-template-areas:
+      "controls controls"
+      "main     main"
+      "tree     bird"
+      "cli      cli";
+    height: auto;
+    min-height: calc(100vh - 3.5rem);
+  }
 
-    .control-panel {
-        flex-direction: row;
-        flex-wrap: wrap;
-        overflow-y: visible;
-        padding-right: 0;
-    }
+  .control-panel {
+    flex-direction: row;
+    flex-wrap: wrap;
+    overflow-y: visible;
+    padding-right: 0;
+  }
 
-    .control-panel section {
-        flex: 1 1 200px;
-        min-width: 180px;
-    }
+  .control-panel section {
+    flex: 1 1 200px;
+    min-width: 180px;
+  }
 
-    .main-view { min-height: 350px; }
+  .main-view {
+    min-height: 350px;
+  }
 }
 
 @media (max-width: 640px) {
-    .workspace-page {
-        grid-template-columns: 1fr;
-        grid-template-rows: auto;
-        grid-template-areas:
-            "controls" "main" "tree" "bird" "cli";
-        gap: 0.5rem;
-        padding: 0;
-    }
+  .workspace-page {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-template-areas: "controls" "main" "tree" "bird" "cli";
+    gap: 0.5rem;
+    padding: 0;
+  }
 
-    .control-panel {
-        display: none;
-        position: fixed;
-        inset: 0;
-        z-index: 50;
-        background: rgba(230, 245, 255, 0.96);
-        backdrop-filter: blur(20px);
-        -webkit-backdrop-filter: blur(20px);
-        padding: 1.5rem;
-        flex-direction: column;
-        overflow-y: auto;
-        gap: 0.75rem;
-    }
+  .control-panel {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    background: rgba(230, 245, 255, 0.96);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    padding: 1.5rem;
+    flex-direction: column;
+    overflow-y: auto;
+    gap: 0.75rem;
+  }
 
-    .control-panel.open { display: flex; }
-    .control-panel section { flex: none; min-width: 0; }
-    .sidebar-toggle { display: flex; }
-    .sidebar-overlay.open { display: block; }
-    .main-view { min-height: 300px; }
-    .tree-view, .bird-view { min-height: 200px; }
-    .cli-section { min-height: 180px; }
+  .control-panel.open {
+    display: flex;
+  }
+  .control-panel section {
+    flex: none;
+    min-width: 0;
+  }
+  .sidebar-toggle {
+    display: flex;
+  }
+  .sidebar-overlay.open {
+    display: block;
+  }
+  .main-view {
+    min-height: 300px;
+  }
+  .tree-view,
+  .bird-view {
+    min-height: 200px;
+  }
+  .cli-section {
+    min-height: 180px;
+  }
 }

--- a/graph-explorer/src/tangled_graph_explorer/static/js/birdview.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/birdview.js
@@ -19,6 +19,9 @@ class BirdView {
     // Main view dimensions for viewport calculation
     this.mainViewWidth = 0;
     this.mainViewHeight = 0;
+
+    this.onNodeSelect = null;
+    this.selectedNodeId = null;
   }
 
   /**
@@ -126,7 +129,16 @@ class BirdView {
       .attr("cx", (d) => d.x || 0)
       .attr("cy", (d) => d.y || 0)
       .attr("r", 4 / this.scale)
-      .attr("fill", "#4a90d9");
+      .attr("fill", (d) =>
+        d.id === this.selectedNodeId ? "#ff69b4" : "#4a90d9",
+      ) // ← roze za selektovan
+      .attr("cursor", "pointer")
+      .on("click", (event, d) => {
+        event.preventDefault();
+        this.selectedNodeId = d.id;
+        this._highlightNode(d.id);
+        if (this.onNodeSelect) this.onNodeSelect(d);
+      });
   }
 
   /**
@@ -155,6 +167,18 @@ class BirdView {
       .attr("y", rectY)
       .attr("width", rectWidth)
       .attr("height", rectHeight);
+  }
+
+  selectNodeById(nodeId) {
+    this.selectedNodeId = nodeId;
+    this._highlightNode(nodeId);
+  }
+
+  _highlightNode(nodeId) {
+    if (!this.mainGroup) return;
+    this.mainGroup
+      .selectAll("circle")
+      .attr("fill", (d) => (d.id === nodeId ? "#ff69b4" : "#4a90d9"));
   }
 }
 

--- a/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/graph.js
@@ -265,7 +265,7 @@ class GraphRenderer {
       .on("click.platform", (event) => {
         const id = d3.select(event.currentTarget).attr("id");
         const node = this._nodeById.get(id);
-        if (node) this._selectNode(node);
+        if (node) this.selectNodeById(node.id);
       })
       .on("mouseover.platform", (event) => {
         const id = d3.select(event.currentTarget).attr("id");
@@ -661,13 +661,48 @@ class GraphRenderer {
   }
 
   _selectNode(node) {
+    if (this.selectedNode) {
+      const prevEl = this.svg
+        ?.node()
+        .querySelector(
+          `${this._nodeSelector}[id="${this.selectedNode.id}"] .node-border`,
+        );
+      if (prevEl) prevEl.style.stroke = "#3a7bc8";
+    }
+
     this.selectedNode = node;
+
+    const el = this.svg
+      ?.node()
+      .querySelector(`${this._nodeSelector}[id="${node.id}"] .node-border`);
+    if (el) el.style.stroke = "#ff69b4";
+
     if (this.onNodeSelect) this.onNodeSelect(node);
   }
 
   selectNodeById(nodeId) {
     const node = this.simulation?.nodes().find((n) => n.id === nodeId);
-    if (node) this._selectNode(node);
+    if (node) {
+      this._selectNode(node);
+      this._zoomToNode(node);
+    }
+  }
+
+  _zoomToNode(node) {
+    if (!this.svg || !this.zoom) return;
+    if (!isFinite(node.x) || !isFinite(node.y)) return;
+
+    const scale = 1.5;
+    const tx = this._w / 2 - node.x * scale;
+    const ty = this._h / 2 - node.y * scale;
+
+    this.svg
+      .transition()
+      .duration(500)
+      .call(
+        this.zoom.transform,
+        d3.zoomIdentity.translate(tx, ty).scale(scale),
+      );
   }
 
   _showTooltip(event, node) {

--- a/graph-explorer/src/tangled_graph_explorer/static/js/treeview.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/treeview.js
@@ -7,405 +7,474 @@
  */
 
 class TreeView {
-    constructor(containerId) {
-        this.containerId = containerId;
-        this.container = document.getElementById(containerId);
-        this.graphData = null;
-        this.adjacencyMap = new Map();
-        this.expandedNodes = new Set();
-        this.selectedNodeId = null;
-        this.rootId = null;
+  constructor(containerId) {
+    this.containerId = containerId;
+    this.container = document.getElementById(containerId);
+    this.graphData = null;
+    this.adjacencyMap = new Map();
+    this.expandedNodes = new Set();
+    this.selectedNodeId = null;
+    this.rootId = null;
 
-        // Callback for node selection
-        this.onNodeSelect = null;
+    // Callback for node selection
+    this.onNodeSelect = null;
+  }
+
+  /**
+   * Render graph data as a tree
+   * @param {Object} data - Graph data with nodes and edges
+   * @param {string} rootId - Optional root node ID
+   */
+  render(data, rootId = null) {
+    if (!this.container || !data || !data.nodes || data.nodes.length === 0) {
+      if (this.container) {
+        this.container.innerHTML =
+          '<p class="tree-placeholder">No data to display</p>';
+      }
+      return;
     }
 
-    /**
-     * Render graph data as a tree
-     * @param {Object} data - Graph data with nodes and edges
-     * @param {string} rootId - Optional root node ID
-     */
-    render(data, rootId = null) {
-        if (!this.container || !data || !data.nodes || data.nodes.length === 0) {
-            if (this.container) {
-                this.container.innerHTML = '<p class="tree-placeholder">No data to display</p>';
-            }
-            return;
+    this.graphData = data;
+    this._buildAdjacencyMap(data);
+
+    // Choose root: explicit > preferred (no incoming edges) > first node
+    if (rootId && this.adjacencyMap.has(rootId)) {
+      this.rootId = rootId;
+    } else if (!this.rootId || !this.adjacencyMap.has(this.rootId)) {
+      this.rootId = this._findBestRoot(data);
+    }
+
+    this._renderTree();
+  }
+
+  /**
+   * Build adjacency map from graph data
+   */
+  _buildAdjacencyMap(data) {
+    this.adjacencyMap.clear();
+    const incomingCount = new Map();
+
+    data.nodes.forEach((node) => {
+      this.adjacencyMap.set(node.id, { node, children: [] });
+      incomingCount.set(node.id, 0);
+    });
+
+    data.edges.forEach((edge) => {
+      const sourceId =
+        typeof edge.source === "object" ? edge.source.id : edge.source;
+      const targetId =
+        typeof edge.target === "object" ? edge.target.id : edge.target;
+
+      const source = this.adjacencyMap.get(sourceId);
+      if (source && this.adjacencyMap.has(targetId)) {
+        source.children.push(targetId);
+        incomingCount.set(targetId, (incomingCount.get(targetId) || 0) + 1);
+      }
+
+      if (data.directed === false) {
+        const target = this.adjacencyMap.get(targetId);
+        if (target && this.adjacencyMap.has(sourceId)) {
+          target.children.push(sourceId);
         }
+      }
+    });
 
-        this.graphData = data;
-        this._buildAdjacencyMap(data);
+    this._incomingCount = incomingCount;
+  }
 
-        // Choose root: explicit > preferred (no incoming edges) > first node
-        if (rootId && this.adjacencyMap.has(rootId)) {
-            this.rootId = rootId;
-        } else if (!this.rootId || !this.adjacencyMap.has(this.rootId)) {
-            this.rootId = this._findBestRoot(data);
+  /**
+   * Find best root node — prefer nodes with no incoming edges
+   */
+  _findBestRoot(data) {
+    if (this._incomingCount) {
+      for (const [nodeId, count] of this._incomingCount) {
+        if (count === 0) return nodeId;
+      }
+    }
+    return data.nodes[0].id;
+  }
+
+  /**
+   * Render the full tree from root
+   */
+  _renderTree() {
+    this.container.innerHTML = "";
+    const fragment = document.createDocumentFragment();
+    const pathSet = new Set();
+    const rendered = new Set();
+
+    const rootEl = this._createNodeElement(this.rootId, pathSet, 0);
+    if (rootEl) {
+      fragment.appendChild(rootEl);
+      rendered.add(this.rootId);
+    }
+
+    for (const [nodeId] of this.adjacencyMap) {
+      if (!rendered.has(nodeId) && !this._isReachable(this.rootId, nodeId)) {
+        const el = this._createNodeElement(nodeId, new Set(), 0);
+        if (el) {
+          fragment.appendChild(el);
+          rendered.add(nodeId);
         }
+      }
+    }
 
+    this.container.appendChild(fragment);
+  }
+
+  _isReachable(fromId, targetId) {
+    const visited = new Set();
+    const queue = [fromId];
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (current === targetId) return true;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const entry = this.adjacencyMap.get(current);
+      if (entry) entry.children.forEach((c) => queue.push(c));
+    }
+    return false;
+  }
+
+  /**
+   * Create a DOM element for a tree node (lazy — children only built when expanded)
+   */
+  _createNodeElement(nodeId, pathSet, depth) {
+    const entry = this.adjacencyMap.get(nodeId);
+    if (!entry) return null;
+
+    const { node, children } = entry;
+    const isCyclic = pathSet.has(nodeId);
+    const hasChildren = children.length > 0;
+    const isExpanded = this.expandedNodes.has(nodeId);
+    const hasAttributes =
+      node.attributes && Object.keys(node.attributes).length > 0;
+
+    // Create node container
+    const nodeEl = document.createElement("div");
+    nodeEl.className = "tree-node";
+    nodeEl.dataset.nodeId = nodeId;
+    if (depth > 0) nodeEl.dataset.depth = depth;
+
+    // Create header row
+    const header = document.createElement("div");
+    header.className = "tree-node-header";
+    if (this.selectedNodeId === nodeId) header.classList.add("selected");
+
+    // Toggle button
+    const toggle = document.createElement("span");
+    toggle.className = "tree-toggle";
+
+    if (isCyclic) {
+      toggle.innerHTML =
+        '<span class="tree-cycle-icon" title="Cyclic reference">&#x21BA;</span>';
+      toggle.classList.add("cyclic");
+    } else if (hasChildren || hasAttributes) {
+      toggle.textContent = isExpanded ? "\u2212" : "+";
+      toggle.dataset.toggle = nodeId;
+    } else {
+      toggle.innerHTML = "&nbsp;";
+    }
+
+    // Label
+    const label = document.createElement("span");
+    label.className = "tree-label";
+    if (isCyclic) {
+      label.classList.add("tree-label-cyclic");
+    }
+    label.textContent = this._getLabel(node);
+    label.title = nodeId;
+
+    header.appendChild(toggle);
+    header.appendChild(label);
+    nodeEl.appendChild(header);
+
+    // Cyclic reference — clicking navigates to the original occurrence
+    if (isCyclic) {
+      header.addEventListener("click", () => {
+        this._selectAndScrollTo(nodeId);
+      });
+      return nodeEl;
+    }
+
+    // Attach header click for selection
+    header.addEventListener("click", (e) => {
+      if (e.target.closest(".tree-toggle[data-toggle]")) return;
+      this._handleSelect(nodeId, header);
+    });
+
+    // Attach toggle click for expand/collapse
+    if (toggle.dataset.toggle) {
+      toggle.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this._handleToggle(nodeId);
+      });
+    }
+
+    // Render expanded content (attributes + children)
+    if (isExpanded && !isCyclic) {
+      this._renderExpandedContent(
+        nodeEl,
+        nodeId,
+        node,
+        children,
+        hasAttributes,
+        pathSet,
+        depth,
+      );
+    }
+
+    return nodeEl;
+  }
+
+  /**
+   * Render attributes and children into an expanded node
+   */
+  _renderExpandedContent(
+    nodeEl,
+    nodeId,
+    node,
+    children,
+    hasAttributes,
+    pathSet,
+    depth,
+  ) {
+    // Attribute list
+    if (hasAttributes) {
+      const attrContainer = document.createElement("div");
+      attrContainer.className = "tree-attributes";
+
+      Object.entries(node.attributes).forEach(([key, attr]) => {
+        const row = document.createElement("div");
+        row.className = "tree-attr-row";
+
+        const keySpan = document.createElement("span");
+        keySpan.className = "tree-attr-key";
+        keySpan.textContent = key;
+
+        const valSpan = document.createElement("span");
+        valSpan.className = "tree-attr-value";
+        const { display, typeClass } = this._formatAttrValue(attr);
+        valSpan.textContent = display;
+        if (typeClass) valSpan.classList.add(typeClass);
+
+        row.appendChild(keySpan);
+        row.appendChild(valSpan);
+        attrContainer.appendChild(row);
+      });
+
+      nodeEl.appendChild(attrContainer);
+    }
+
+    // Children
+    if (children.length > 0) {
+      const childrenContainer = document.createElement("div");
+      childrenContainer.className = "tree-children";
+
+      pathSet.add(nodeId);
+      children.forEach((childId) => {
+        const childEl = this._createNodeElement(childId, pathSet, depth + 1);
+        if (childEl) childrenContainer.appendChild(childEl);
+      });
+      pathSet.delete(nodeId);
+
+      nodeEl.appendChild(childrenContainer);
+    }
+  }
+
+  /**
+   * Handle toggle expand/collapse
+   */
+  _handleToggle(nodeId) {
+    if (this.expandedNodes.has(nodeId)) {
+      this.expandedNodes.delete(nodeId);
+    } else {
+      this.expandedNodes.add(nodeId);
+    }
+
+    // Full re-render from root to guarantee correct cycle detection
+    // (subtree re-render would lose ancestor context for cycle paths)
+    this._renderTree();
+  }
+
+  /**
+   * Handle node selection
+   */
+  _handleSelect(nodeId, headerEl) {
+    // Remove previous selection
+    this.container
+      .querySelectorAll(".tree-node-header.selected")
+      .forEach((h) => {
+        h.classList.remove("selected");
+      });
+    headerEl.classList.add("selected");
+    this.selectedNodeId = nodeId;
+
+    if (this.onNodeSelect) {
+      const node = this.graphData.nodes.find((n) => n.id === nodeId);
+      if (node) this.onNodeSelect(node);
+    }
+  }
+
+  /**
+   * Select and scroll to a node — used for cyclic reference clicks
+   */
+  _selectAndScrollTo(nodeId) {
+    // Find the first non-cyclic occurrence of this node
+    const allMatches = this.container.querySelectorAll(
+      `.tree-node[data-node-id="${CSS.escape(nodeId)}"]`,
+    );
+    for (const el of allMatches) {
+      if (el.querySelector(".tree-cycle-icon")) continue;
+      const header = el.querySelector(".tree-node-header");
+      if (!header) continue;
+      this._handleSelect(nodeId, header);
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
+  }
+
+  /**
+   * Select node by ID — cross-view sync with auto-expand path
+   * @param {string} nodeId
+   */
+  selectNodeById(nodeId) {
+    if (!this.graphData || !this.adjacencyMap.has(nodeId)) return;
+
+    this.selectedNodeId = nodeId;
+
+    // Find path from root to target using BFS
+    const path = this._findPathBFS(this.rootId, nodeId);
+    if (path) {
+      // Expand all ancestors (not the target itself unless it was already expanded)
+      let needsRerender = false;
+      for (let i = 0; i < path.length - 1; i++) {
+        if (!this.expandedNodes.has(path[i])) {
+          this.expandedNodes.add(path[i]);
+          needsRerender = true;
+        }
+      }
+      if (needsRerender) {
         this._renderTree();
+      }
     }
 
-    /**
-     * Build adjacency map from graph data
-     */
-    _buildAdjacencyMap(data) {
-        this.adjacencyMap.clear();
-        const incomingCount = new Map();
+    // Highlight and scroll
+    this.container
+      .querySelectorAll(".tree-node-header.selected")
+      .forEach((h) => {
+        h.classList.remove("selected");
+      });
 
-        data.nodes.forEach(node => {
-            this.adjacencyMap.set(node.id, { node, children: [] });
-            incomingCount.set(node.id, 0);
-        });
+    const target = this.container.querySelector(
+      `.tree-node[data-node-id="${CSS.escape(nodeId)}"] > .tree-node-header`,
+    );
+    if (target) {
+      target.classList.add("selected");
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }
 
-        data.edges.forEach(edge => {
-            const sourceId = typeof edge.source === 'object' ? edge.source.id : edge.source;
-            const targetId = typeof edge.target === 'object' ? edge.target.id : edge.target;
+  /**
+   * BFS to find path from source to target using parent map
+   * @returns {Array|null} Array of node IDs from source to target, or null
+   */
+  _findPathBFS(sourceId, targetId) {
+    if (sourceId === targetId) return [sourceId];
 
-            const source = this.adjacencyMap.get(sourceId);
-            if (source && this.adjacencyMap.has(targetId)) {
-                source.children.push(targetId);
-                incomingCount.set(targetId, (incomingCount.get(targetId) || 0) + 1);
-            }
+    const visited = new Set([sourceId]);
+    const parent = new Map();
+    const queue = [sourceId];
 
-            if (data.directed === false) {
-                const target = this.adjacencyMap.get(targetId);
-                if (target && this.adjacencyMap.has(sourceId)) {
-                    target.children.push(sourceId);
-                }
-            }
-        });
+    while (queue.length > 0) {
+      const current = queue.shift();
+      const entry = this.adjacencyMap.get(current);
+      if (!entry) continue;
 
-        this._incomingCount = incomingCount;
+      for (const childId of entry.children) {
+        if (visited.has(childId)) continue;
+        parent.set(childId, current);
+        if (childId === targetId) {
+          // Reconstruct path
+          const path = [targetId];
+          let node = targetId;
+          while (node !== sourceId) {
+            node = parent.get(node);
+            path.unshift(node);
+          }
+          return path;
+        }
+        visited.add(childId);
+        queue.push(childId);
+      }
     }
 
-    /**
-     * Find best root node — prefer nodes with no incoming edges
-     */
-    _findBestRoot(data) {
-        if (this._incomingCount) {
-            for (const [nodeId, count] of this._incomingCount) {
-                if (count === 0) return nodeId;
-            }
+    return null;
+  }
+
+  /**
+   * Get display label for a node
+   */
+  _getLabel(node) {
+    // Prefer common name-like attributes
+    if (node.attributes) {
+      for (const key of ["name", "label", "title", "first"]) {
+        const attr = node.attributes[key];
+        if (attr) {
+          const val = typeof attr === "object" ? attr.value : attr;
+          if (val != null && val !== "") return String(val);
         }
-        return data.nodes[0].id;
+      }
+    }
+    if (node.label) return node.label;
+    return String(node.id);
+  }
+
+  /**
+   * Format attribute value for display with type awareness
+   */
+  _formatAttrValue(attr) {
+    if (attr === null || attr === undefined) {
+      return { display: "null", typeClass: "attr-type-null" };
     }
 
-    /**
-     * Render the full tree from root
-     */
-    _renderTree() {
-        this.container.innerHTML = '';
+    const value =
+      typeof attr === "object" && attr.value !== undefined ? attr.value : attr;
+    const type =
+      typeof attr === "object" && attr.type ? attr.type : typeof value;
 
-        const fragment = document.createDocumentFragment();
-        const pathSet = new Set();
-        const rootEl = this._createNodeElement(this.rootId, pathSet, 0);
-        if (rootEl) fragment.appendChild(rootEl);
-
-        this.container.appendChild(fragment);
+    switch (type) {
+      case "number":
+      case "integer":
+      case "float":
+        return { display: String(value), typeClass: "attr-type-number" };
+      case "boolean":
+        return { display: String(value), typeClass: "attr-type-boolean" };
+      case "date":
+      case "datetime": {
+        const d = new Date(value);
+        const display = isNaN(d.getTime())
+          ? String(value)
+          : d.toLocaleDateString();
+        return { display, typeClass: "attr-type-date" };
+      }
+      case "string":
+      default:
+        return { display: `"${value}"`, typeClass: "attr-type-string" };
     }
+  }
 
-    /**
-     * Create a DOM element for a tree node (lazy — children only built when expanded)
-     */
-    _createNodeElement(nodeId, pathSet, depth) {
-        const entry = this.adjacencyMap.get(nodeId);
-        if (!entry) return null;
-
-        const { node, children } = entry;
-        const isCyclic = pathSet.has(nodeId);
-        const hasChildren = children.length > 0;
-        const isExpanded = this.expandedNodes.has(nodeId);
-        const hasAttributes = node.attributes && Object.keys(node.attributes).length > 0;
-
-        // Create node container
-        const nodeEl = document.createElement('div');
-        nodeEl.className = 'tree-node';
-        nodeEl.dataset.nodeId = nodeId;
-        if (depth > 0) nodeEl.dataset.depth = depth;
-
-        // Create header row
-        const header = document.createElement('div');
-        header.className = 'tree-node-header';
-        if (this.selectedNodeId === nodeId) header.classList.add('selected');
-
-        // Toggle button
-        const toggle = document.createElement('span');
-        toggle.className = 'tree-toggle';
-
-        if (isCyclic) {
-            toggle.innerHTML = '<span class="tree-cycle-icon" title="Cyclic reference">&#x21BA;</span>';
-            toggle.classList.add('cyclic');
-        } else if (hasChildren || hasAttributes) {
-            toggle.textContent = isExpanded ? '\u2212' : '+';
-            toggle.dataset.toggle = nodeId;
-        } else {
-            toggle.innerHTML = '&nbsp;';
-        }
-
-        // Label
-        const label = document.createElement('span');
-        label.className = 'tree-label';
-        if (isCyclic) {
-            label.classList.add('tree-label-cyclic');
-        }
-        label.textContent = this._getLabel(node);
-        label.title = nodeId;
-
-        header.appendChild(toggle);
-        header.appendChild(label);
-        nodeEl.appendChild(header);
-
-        // Cyclic reference — clicking navigates to the original occurrence
-        if (isCyclic) {
-            header.addEventListener('click', () => {
-                this._selectAndScrollTo(nodeId);
-            });
-            return nodeEl;
-        }
-
-        // Attach header click for selection
-        header.addEventListener('click', (e) => {
-            if (e.target.closest('.tree-toggle[data-toggle]')) return;
-            this._handleSelect(nodeId, header);
-        });
-
-        // Attach toggle click for expand/collapse
-        if (toggle.dataset.toggle) {
-            toggle.addEventListener('click', (e) => {
-                e.stopPropagation();
-                this._handleToggle(nodeId);
-            });
-        }
-
-        // Render expanded content (attributes + children)
-        if (isExpanded && !isCyclic) {
-            this._renderExpandedContent(nodeEl, nodeId, node, children, hasAttributes, pathSet, depth);
-        }
-
-        return nodeEl;
+  clear() {
+    this.graphData = null;
+    this.adjacencyMap.clear();
+    this.expandedNodes.clear();
+    this.selectedNodeId = null;
+    this.rootId = null;
+    if (this.container) {
+      this.container.innerHTML =
+        '<p class="tree-placeholder">Load data to see tree view</p>';
     }
-
-    /**
-     * Render attributes and children into an expanded node
-     */
-    _renderExpandedContent(nodeEl, nodeId, node, children, hasAttributes, pathSet, depth) {
-        // Attribute list
-        if (hasAttributes) {
-            const attrContainer = document.createElement('div');
-            attrContainer.className = 'tree-attributes';
-
-            Object.entries(node.attributes).forEach(([key, attr]) => {
-                const row = document.createElement('div');
-                row.className = 'tree-attr-row';
-
-                const keySpan = document.createElement('span');
-                keySpan.className = 'tree-attr-key';
-                keySpan.textContent = key;
-
-                const valSpan = document.createElement('span');
-                valSpan.className = 'tree-attr-value';
-                const { display, typeClass } = this._formatAttrValue(attr);
-                valSpan.textContent = display;
-                if (typeClass) valSpan.classList.add(typeClass);
-
-                row.appendChild(keySpan);
-                row.appendChild(valSpan);
-                attrContainer.appendChild(row);
-            });
-
-            nodeEl.appendChild(attrContainer);
-        }
-
-        // Children
-        if (children.length > 0) {
-            const childrenContainer = document.createElement('div');
-            childrenContainer.className = 'tree-children';
-
-            pathSet.add(nodeId);
-            children.forEach(childId => {
-                const childEl = this._createNodeElement(childId, pathSet, depth + 1);
-                if (childEl) childrenContainer.appendChild(childEl);
-            });
-            pathSet.delete(nodeId);
-
-            nodeEl.appendChild(childrenContainer);
-        }
-    }
-
-    /**
-     * Handle toggle expand/collapse
-     */
-    _handleToggle(nodeId) {
-        if (this.expandedNodes.has(nodeId)) {
-            this.expandedNodes.delete(nodeId);
-        } else {
-            this.expandedNodes.add(nodeId);
-        }
-
-        // Full re-render from root to guarantee correct cycle detection
-        // (subtree re-render would lose ancestor context for cycle paths)
-        this._renderTree();
-    }
-
-    /**
-     * Handle node selection
-     */
-    _handleSelect(nodeId, headerEl) {
-        // Remove previous selection
-        this.container.querySelectorAll('.tree-node-header.selected').forEach(h => {
-            h.classList.remove('selected');
-        });
-        headerEl.classList.add('selected');
-        this.selectedNodeId = nodeId;
-
-        if (this.onNodeSelect) {
-            const node = this.graphData.nodes.find(n => n.id === nodeId);
-            if (node) this.onNodeSelect(node);
-        }
-    }
-
-    /**
-     * Select and scroll to a node — used for cyclic reference clicks
-     */
-    _selectAndScrollTo(nodeId) {
-        // Find the first non-cyclic occurrence of this node
-        const allMatches = this.container.querySelectorAll(
-            `.tree-node[data-node-id="${CSS.escape(nodeId)}"]`
-        );
-        for (const el of allMatches) {
-            if (el.querySelector('.tree-cycle-icon')) continue;
-            const header = el.querySelector('.tree-node-header');
-            if (!header) continue;
-            this._handleSelect(nodeId, header);
-            el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            return;
-        }
-    }
-
-    /**
-     * Select node by ID — cross-view sync with auto-expand path
-     * @param {string} nodeId
-     */
-    selectNodeById(nodeId) {
-        if (!this.graphData || !this.adjacencyMap.has(nodeId)) return;
-
-        this.selectedNodeId = nodeId;
-
-        // Find path from root to target using BFS
-        const path = this._findPathBFS(this.rootId, nodeId);
-        if (path) {
-            // Expand all ancestors (not the target itself unless it was already expanded)
-            let needsRerender = false;
-            for (let i = 0; i < path.length - 1; i++) {
-                if (!this.expandedNodes.has(path[i])) {
-                    this.expandedNodes.add(path[i]);
-                    needsRerender = true;
-                }
-            }
-            if (needsRerender) {
-                this._renderTree();
-            }
-        }
-
-        // Highlight and scroll
-        this.container.querySelectorAll('.tree-node-header.selected').forEach(h => {
-            h.classList.remove('selected');
-        });
-
-        const target = this.container.querySelector(
-            `.tree-node[data-node-id="${CSS.escape(nodeId)}"] > .tree-node-header`
-        );
-        if (target) {
-            target.classList.add('selected');
-            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-    }
-
-    /**
-     * BFS to find path from source to target using parent map
-     * @returns {Array|null} Array of node IDs from source to target, or null
-     */
-    _findPathBFS(sourceId, targetId) {
-        if (sourceId === targetId) return [sourceId];
-
-        const visited = new Set([sourceId]);
-        const parent = new Map();
-        const queue = [sourceId];
-
-        while (queue.length > 0) {
-            const current = queue.shift();
-            const entry = this.adjacencyMap.get(current);
-            if (!entry) continue;
-
-            for (const childId of entry.children) {
-                if (visited.has(childId)) continue;
-                parent.set(childId, current);
-                if (childId === targetId) {
-                    // Reconstruct path
-                    const path = [targetId];
-                    let node = targetId;
-                    while (node !== sourceId) {
-                        node = parent.get(node);
-                        path.unshift(node);
-                    }
-                    return path;
-                }
-                visited.add(childId);
-                queue.push(childId);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Get display label for a node
-     */
-    _getLabel(node) {
-        // Prefer common name-like attributes
-        if (node.attributes) {
-            for (const key of ['name', 'label', 'title', 'first']) {
-                const attr = node.attributes[key];
-                if (attr) {
-                    const val = typeof attr === 'object' ? attr.value : attr;
-                    if (val != null && val !== '') return String(val);
-                }
-            }
-        }
-        if (node.label) return node.label;
-        return String(node.id);
-    }
-
-    /**
-     * Format attribute value for display with type awareness
-     */
-    _formatAttrValue(attr) {
-        if (attr === null || attr === undefined) {
-            return { display: 'null', typeClass: 'attr-type-null' };
-        }
-
-        const value = typeof attr === 'object' && attr.value !== undefined ? attr.value : attr;
-        const type = typeof attr === 'object' && attr.type ? attr.type : typeof value;
-
-        switch (type) {
-            case 'number':
-            case 'integer':
-            case 'float':
-                return { display: String(value), typeClass: 'attr-type-number' };
-            case 'boolean':
-                return { display: String(value), typeClass: 'attr-type-boolean' };
-            case 'date':
-            case 'datetime': {
-                const d = new Date(value);
-                const display = isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
-                return { display, typeClass: 'attr-type-date' };
-            }
-            case 'string':
-            default:
-                return { display: `"${value}"`, typeClass: 'attr-type-string' };
-        }
-    }
+  }
 }
 
 // Export for use in workspace.js

--- a/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
@@ -19,6 +19,7 @@ class WorkspaceController {
     this._setupEventHandlers();
     this._setupViewSynchronization();
     this._loadDataSources();
+    this._isCleared = false;
   }
 
   /**
@@ -68,11 +69,38 @@ class WorkspaceController {
 
     // CLI form
     const cliForm = document.getElementById("cli-form");
+    const cliInput = document.getElementById("cli-input");
+    this._cliHistory = [];
+    this._cliHistoryIndex = -1;
+
+    cliInput?.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (this._cliHistoryIndex < this._cliHistory.length - 1) {
+          this._cliHistoryIndex++;
+          cliInput.value = this._cliHistory[this._cliHistoryIndex];
+        }
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (this._cliHistoryIndex > 0) {
+          this._cliHistoryIndex--;
+          cliInput.value = this._cliHistory[this._cliHistoryIndex];
+        } else {
+          this._cliHistoryIndex = -1;
+          cliInput.value = "";
+        }
+      }
+    });
+
     cliForm?.addEventListener("submit", (e) => {
       e.preventDefault();
-      const command = document.getElementById("cli-input").value;
+      const command = cliInput.value;
+      if (command) {
+        this._cliHistory.unshift(command);
+        this._cliHistoryIndex = -1;
+      }
       this._handleCliCommand(command);
-      document.getElementById("cli-input").value = "";
+      cliInput.value = "";
     });
   }
 
@@ -83,11 +111,17 @@ class WorkspaceController {
     // Sync node selection across views
     this.graphRenderer.onNodeSelect = (node) => {
       this.treeView.selectNodeById(node.id);
-      // Bird view doesn't need selection sync
+      this.birdView.selectNodeById(node.id);
     };
 
     this.treeView.onNodeSelect = (node) => {
       this.graphRenderer.selectNodeById(node.id);
+      this.birdView.selectNodeById(node.id);
+    };
+
+    this.birdView.onNodeSelect = (node) => {
+      this.graphRenderer.selectNodeById(node.id);
+      this.treeView.selectNodeById(node.id);
     };
 
     // Sync viewport changes to bird view
@@ -247,22 +281,33 @@ class WorkspaceController {
    */
   async _handleSearch(query) {
     if (!query) return;
-
     try {
       const result = await api.post(
         `/api/workspace/${this.workspaceId}/search`,
         { query },
       );
-
       if (result.error) {
         showNotification(result.error, "error");
       } else {
         showNotification(`Found ${result.node_count} nodes`, "info");
-        await this._refreshVisualization();
+        await this._refreshData();
       }
     } catch (error) {
       showNotification("Search failed", "error");
-      console.error(error);
+    }
+  }
+
+  async _refreshData() {
+    try {
+      const graphData = await api.get(
+        `/api/workspace/${this.workspaceId}/graph`,
+      );
+      this.graphData = graphData;
+      this.graphRenderer.update(graphData);
+      this.birdView.render(graphData);
+      this.treeView.render(graphData);
+    } catch (error) {
+      console.error("Failed to refresh data:", error);
     }
   }
 
@@ -282,7 +327,7 @@ class WorkspaceController {
         showNotification(result.error, "error");
       } else {
         showNotification(`Filtered to ${result.node_count} nodes`, "info");
-        await this._refreshVisualization();
+        await this._refreshData();
       }
     } catch (error) {
       showNotification("Filter failed", "error");
@@ -298,7 +343,7 @@ class WorkspaceController {
       await api.post(`/api/workspace/${this.workspaceId}/reset`);
       document.getElementById("search-input").value = "";
       document.getElementById("filter-input").value = "";
-      await this._refreshVisualization();
+      await this._refreshData();
       showNotification("Reset to original graph", "info");
     } catch (error) {
       showNotification("Reset failed", "error");
@@ -324,14 +369,45 @@ class WorkspaceController {
         output.innerHTML += `<div class="cli-error">${result.error}</div>`;
       } else {
         output.innerHTML += `<div class="cli-result">${result.result || "OK"}</div>`;
-        await this._refreshVisualization();
+
+        if (result.changed) {
+          const clearRe = /^clear\b/i;
+          const structuralRe = /^(filter|search|reset)\b/i;
+
+          if (clearRe.test(command.trim())) {
+            this._clearViews();
+          } else if (structuralRe.test(command.trim())) {
+            this._isCleared = false;
+            await this._refreshVisualization();
+          } else {
+            if (!this._isCleared) {
+              await this._refreshData();
+            }
+          }
+        }
       }
     } catch (error) {
       output.innerHTML += `<div class="cli-error">Command failed</div>`;
     }
 
-    // Scroll to bottom
     output.scrollTop = output.scrollHeight;
+  }
+
+  _clearViews() {
+    this._isCleared = true;
+    this.graphData = null;
+    const mainContainer = document.getElementById("main-graph-container");
+    mainContainer.innerHTML =
+      '<p class="placeholder">Load data to visualize graph</p>';
+    this.birdView.init();
+    this.treeView.clear?.();
+
+    const dataSourceSelect = document.getElementById("data-source-select");
+    if (dataSourceSelect) dataSourceSelect.value = "";
+    document.getElementById("plugin-params").innerHTML = "";
+
+    document.getElementById("search-input").value = "";
+    document.getElementById("filter-input").value = "";
   }
 }
 

--- a/graph-explorer/src/tangled_graph_explorer/templates/base.html
+++ b/graph-explorer/src/tangled_graph_explorer/templates/base.html
@@ -1,113 +1,167 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}Tangled Graph Explorer{% endblock %}</title>
 
     <!-- Tailwind CSS v4 (Browser) -->
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"
+    ></script>
 
     <!-- Fonts: Fredoka (brand/headings) + Quicksand (body) + JetBrains Mono (code) -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600;700&family=Quicksand:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600;700&family=Quicksand:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
 
     <!-- Tailwind v4 Custom Theme — Pool Blue + Bubblegum Pink -->
     <style type="text/tailwindcss">
-        @theme {
-            --font-brand: 'Fredoka', sans-serif;
-            --font-sans: 'Quicksand', sans-serif;
-            --font-mono: 'JetBrains Mono', monospace;
+      @theme {
+        --font-brand: "Fredoka", sans-serif;
+        --font-sans: "Quicksand", sans-serif;
+        --font-mono: "JetBrains Mono", monospace;
 
-            /* ── Custom colorways ── */
-            --color-pool: #40C9FF;
-            --color-pool-light: #7DDDFF;
-            --color-pool-lighter: #B5ECFF;
-            --color-pool-pale: #E0F6FF;
-            --color-pool-dark: #0BA5E0;
+        /* ── Custom colorways ── */
+        --color-pool: #40c9ff;
+        --color-pool-light: #7dddff;
+        --color-pool-lighter: #b5ecff;
+        --color-pool-pale: #e0f6ff;
+        --color-pool-dark: #0ba5e0;
 
-            --color-bubblegum: #FF6B9D;
-            --color-bubblegum-light: #FF9DBF;
-            --color-bubblegum-lighter: #FFCBDD;
-            --color-bubblegum-pale: #FFE8F0;
+        --color-bubblegum: #ff6b9d;
+        --color-bubblegum-light: #ff9dbf;
+        --color-bubblegum-lighter: #ffcbdd;
+        --color-bubblegum-pale: #ffe8f0;
 
-            --color-navy: #1B2A5C;
-            --color-navy-light: #2D4080;
-            --color-navy-muted: rgba(27, 42, 92, 0.55);
-            --color-navy-faint: rgba(27, 42, 92, 0.3);
+        --color-navy: #1b2a5c;
+        --color-navy-light: #2d4080;
+        --color-navy-muted: rgba(27, 42, 92, 0.55);
+        --color-navy-faint: rgba(27, 42, 92, 0.3);
 
-            --color-glass-50: rgba(255, 255, 255, 0.5);
-            --color-glass-40: rgba(255, 255, 255, 0.4);
-            --color-glass-30: rgba(255, 255, 255, 0.3);
-        }
+        --color-glass-50: rgba(255, 255, 255, 0.5);
+        --color-glass-40: rgba(255, 255, 255, 0.4);
+        --color-glass-30: rgba(255, 255, 255, 0.3);
+      }
     </style>
 
     <!-- Base styles -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/style.css') }}"
+    />
     {% block head %}{% endblock %}
-</head>
-<body class="font-sans antialiased text-navy overflow-x-hidden"
-      style="background: #E0F6FF; min-height: 100vh; opacity: 0; transition: opacity 0.3s ease;">
-
+  </head>
+  <body
+    class="font-sans antialiased text-navy overflow-x-hidden"
+    style="
+      background: #e0f6ff;
+      min-height: 100vh;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    "
+  >
     <!-- Header -->
-    <header class="glass fixed top-0 left-0 right-0 z-50 animate-fade-in-up"
-            style="border-top: none; border-left: none; border-right: none; border-radius: 0;">
-        <div class="max-w-[1800px] mx-auto flex items-center justify-between px-5 py-2">
-            <!-- Brand -->
-            <a href="{{ url_for('main.index') }}"
-               class="flex items-center gap-2.5 no-underline group">
-                <!-- Logo bubble -->
-                <div class="w-10 h-10 rounded-full flex items-center justify-center relative"
-                     style="background: linear-gradient(135deg, #40C9FF, #7DDDFF); box-shadow: 0 4px 15px rgba(64, 201, 255, 0.35);">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="5" r="2"/>
-                        <circle cx="5" cy="19" r="2"/>
-                        <circle cx="19" cy="19" r="2"/>
-                        <line x1="12" y1="7" x2="5" y2="17"/>
-                        <line x1="12" y1="7" x2="19" y2="17"/>
-                        <line x1="5" y1="19" x2="19" y2="19"/>
-                    </svg>
-                    <!-- Glossy bubble highlight -->
-                    <div class="absolute top-1 left-1.5 w-3 h-2 rounded-full bg-white opacity-50"></div>
-                </div>
-                <span class="font-brand text-2xl font-bold text-bubblegum
-                             group-hover:text-bubblegum-light transition-colors">
-                    Tangled
-                </span>
-            </a>
+    <header
+      class="glass fixed top-0 left-0 right-0 z-50 animate-fade-in-up"
+      style="
+        border-top: none;
+        border-left: none;
+        border-right: none;
+        border-radius: 0;
+      "
+    >
+      <div
+        class="max-w-[1800px] mx-auto flex items-center justify-between px-5 py-2"
+      >
+        <!-- Brand -->
+        <a
+          href="{{ url_for('main.index') }}"
+          class="flex items-center gap-2.5 no-underline group"
+        >
+          <!-- Logo bubble -->
+          <div
+            class="w-10 h-10 rounded-full flex items-center justify-center relative"
+            style="
+              background: linear-gradient(135deg, #40c9ff, #7dddff);
+              box-shadow: 0 4px 15px rgba(64, 201, 255, 0.35);
+            "
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="white"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <circle cx="12" cy="5" r="2" />
+              <circle cx="5" cy="19" r="2" />
+              <circle cx="19" cy="19" r="2" />
+              <line x1="12" y1="7" x2="5" y2="17" />
+              <line x1="12" y1="7" x2="19" y2="17" />
+              <line x1="5" y1="19" x2="19" y2="19" />
+            </svg>
+            <!-- Glossy bubble highlight -->
+            <div
+              class="absolute top-1 left-1.5 w-3 h-2 rounded-full bg-white opacity-50"
+            ></div>
+          </div>
+          <span
+            class="font-brand text-2xl font-bold text-bubblegum group-hover:text-bubblegum-light transition-colors"
+          >
+            Tangled
+          </span>
+        </a>
 
-            <!-- Navigation -->
-            <nav class="flex items-center gap-1">
-                <a href="{{ url_for('main.index') }}"
-                   class="px-3.5 py-1.5 rounded-lg text-sm font-bold transition-all duration-200
-                          text-navy-muted hover:text-navy hover:bg-glass-40 no-underline">
-                    Home
-                </a>
-                <a href="{{ url_for('main.new_workspace') }}"
-                   class="btn-glow text-sm !py-1.5 !px-4 !rounded-lg no-underline">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
-                        <line x1="12" y1="5" x2="12" y2="19"/>
-                        <line x1="5" y1="12" x2="19" y2="12"/>
-                    </svg>
-                    New Workspace
-                </a>
-            </nav>
-        </div>
+        <!-- Navigation -->
+        <nav class="flex items-center gap-1">
+          <a
+            href="{{ url_for('main.index') }}"
+            class="px-3.5 py-1.5 rounded-lg text-sm font-bold transition-all duration-200 text-navy-muted hover:text-navy hover:bg-glass-40 no-underline"
+          >
+            Home
+          </a>
+          <a
+            href="{{ url_for('main.new_workspace') }}"
+            class="btn-glow text-sm !py-1.5 !px-4 !rounded-lg no-underline"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            New Workspace
+          </a>
+        </nav>
+      </div>
     </header>
 
     <!-- Main Content -->
-    <main class="relative z-10 pt-[2.75rem] px-3 pb-4 min-h-screen">
-        <div class="max-w-[1800px] mx-auto">
-            {% block content %}{% endblock %}
-        </div>
+    <main class="relative z-10 pt-[1rem] px-3 pb-4 min-h-screen">
+      <div class="max-w-[1800px] mx-auto">
+        {% block content %}{% endblock %}
+      </div>
     </main>
 
     <!-- Footer -->
     <footer class="relative z-10 text-center py-4 px-4">
-        <p class="text-xs text-navy-faint font-bold tracking-wide">
-            Tangled Graph Explorer &copy; 2026
-        </p>
+      <p class="text-xs text-navy-faint font-bold tracking-wide">
+        Tangled Graph Explorer &copy; 2026
+      </p>
     </footer>
 
     <!-- Toast Container -->
@@ -117,10 +171,12 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     <script>
-    history.scrollRestoration = 'manual';
-    window.scrollTo(0, 0);
-    window.addEventListener('load', function() { document.body.style.opacity = '1'; });
+      history.scrollRestoration = "manual";
+      window.scrollTo(0, 0);
+      window.addEventListener("load", function () {
+        document.body.style.opacity = "1";
+      });
     </script>
     {% block scripts %}{% endblock %}
-</body>
+  </body>
 </html>

--- a/simple-visualizer/src/tangled_simple_visualizer/template/template.html
+++ b/simple-visualizer/src/tangled_simple_visualizer/template/template.html
@@ -71,6 +71,7 @@
       const textSize=14;
       d3.selectAll('.node').append('circle')
           .attr('r', radius+textSize)
+          .attr('class', 'node-border')
           .style('fill', 'white')
           .style('stroke', '#04446fff')
           .style('stroke-width', '1.5px')


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to both the plugin development documentation and the JavaScript front-end components for graph visualization and tree views. The main changes improve plugin conventions, node selection and highlighting in visualizations, and tree rendering logic for disconnected nodes.

**Documentation improvements and plugin conventions:**

* Added detailed conventions for Visualizer plugins, specifying required SVG attributes and CSS classes to ensure compatibility with the platform's GraphRenderer. This includes `data-*` attributes on the root `<svg>` and class/id requirements for node elements.
* Clarified that DataSource plugins should read the `directed` flag from input files (JSON/YAML/XML) rather than hardcoding graph directionality, improving plugin flexibility.

**Graph visualization and selection enhancements:**

* Updated `BirdView` and `GraphRenderer` classes to support node selection and highlighting: clicking a node now visually highlights it, and `GraphRenderer` zooms to the selected node with an animated transition. [[1]](diffhunk://#diff-6522ddabe0656fb2ba23ef19e3007e1647aa918b0ff6ee94fa72769c6f84a929L129-R141) [[2]](diffhunk://#diff-6522ddabe0656fb2ba23ef19e3007e1647aa918b0ff6ee94fa72769c6f84a929R171-R182) [[3]](diffhunk://#diff-c4912e228cea454bce4101624d3be5c3cdb2001b07267c05c146c22e5d964377R664-R705)
* Refactored selection logic to ensure consistent highlighting and zooming behavior when nodes are selected via click or programmatically.

**Tree view rendering fixes and improvements:**

* Refactored `TreeView` to use consistent code style and improved logic for rendering disconnected nodes: now, nodes not reachable from the root are rendered separately, ensuring all nodes in the graph are visible.
* Improved cyclic reference handling and selection logic in `TreeView`, including smoother scrolling and more robust event handling for node selection. [[1]](diffhunk://#diff-4f112a5d995f073a8f81725c08b5079e1c3d1f9377d21211c2d7ec0ac5fa7b36L119-R183) [[2]](diffhunk://#diff-4f112a5d995f073a8f81725c08b5079e1c3d1f9377d21211c2d7ec0ac5fa7b36L192-R256) [[3]](diffhunk://#diff-4f112a5d995f073a8f81725c08b5079e1c3d1f9377d21211c2d7ec0ac5fa7b36L256-R314) [[4]](diffhunk://#diff-4f112a5d995f073a8f81725c08b5079e1c3d1f9377d21211c2d7ec0ac5fa7b36L274-R332)

Closes #38 