### PR TITLE
Fix workspace loading issues

### DIFF
--- a/graph-explorer-django/src/tangled_django/explorer/static/js/workspace.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/workspace.js
@@ -20,6 +20,66 @@ class WorkspaceController {
     this._setupViewSynchronization();
     this._loadDataSources();
     this._isCleared = false;
+
+    this._autoRestore();
+  }
+
+  async _autoRestore() {
+    try {
+      const graphData = await api.get(
+        `/api/workspace/${this.workspaceId}/graph`,
+      );
+      if (graphData.nodes && graphData.nodes.length > 0) {
+        await this._refreshVisualization();
+      }
+    } catch (error) {
+      console.error("Failed to restore workspace state:", error);
+    }
+  }
+
+  _saveUIState() {
+    const pluginId = document.getElementById("data-source-select").value;
+    const visualizer = document.getElementById("visualizer-select").value;
+    const params = {};
+    document.querySelectorAll("#plugin-params input").forEach((input) => {
+      if (input.value) params[input.name] = input.value;
+    });
+
+    localStorage.setItem(
+      `ws_${this.workspaceId}`,
+      JSON.stringify({
+        pluginId,
+        visualizer,
+        params,
+      }),
+    );
+  }
+
+  _restoreUIState() {
+    const saved = localStorage.getItem(`ws_${this.workspaceId}`);
+    if (!saved) return;
+
+    const { pluginId, visualizer, params } = JSON.parse(saved);
+
+    const dataSourceSelect = document.getElementById("data-source-select");
+    if (pluginId && dataSourceSelect) {
+      dataSourceSelect.value = pluginId;
+      this._updatePluginParams(pluginId);
+
+      if (params) {
+        Object.entries(params).forEach(([name, value]) => {
+          const input = document.querySelector(
+            `#plugin-params input[name="${name}"]`,
+          );
+          if (input) input.value = value;
+        });
+      }
+    }
+
+    const visualizerSelect = document.getElementById("visualizer-select");
+    if (visualizer && visualizerSelect) {
+      visualizerSelect.value = visualizer;
+    }
   }
 
   /**
@@ -153,6 +213,7 @@ class WorkspaceController {
         option.dataset.params = JSON.stringify(source.parameters);
         select.appendChild(option);
       });
+      this._restoreUIState();
     } catch (error) {
       console.error("Failed to load data sources:", error);
     }
@@ -222,6 +283,7 @@ class WorkspaceController {
         showNotification(result.error, "error");
       } else {
         showNotification(`Loaded ${result.node_count} nodes`, "success");
+        this._saveUIState();
         await this._refreshVisualization();
       }
     } catch (error) {

--- a/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
@@ -20,6 +20,66 @@ class WorkspaceController {
     this._setupViewSynchronization();
     this._loadDataSources();
     this._isCleared = false;
+
+    this._autoRestore();
+  }
+
+  async _autoRestore() {
+    try {
+      const graphData = await api.get(
+        `/api/workspace/${this.workspaceId}/graph`,
+      );
+      if (graphData.nodes && graphData.nodes.length > 0) {
+        await this._refreshVisualization();
+      }
+    } catch (error) {
+      console.error("Failed to restore workspace state:", error);
+    }
+  }
+
+  _saveUIState() {
+    const pluginId = document.getElementById("data-source-select").value;
+    const visualizer = document.getElementById("visualizer-select").value;
+    const params = {};
+    document.querySelectorAll("#plugin-params input").forEach((input) => {
+      if (input.value) params[input.name] = input.value;
+    });
+
+    localStorage.setItem(
+      `ws_${this.workspaceId}`,
+      JSON.stringify({
+        pluginId,
+        visualizer,
+        params,
+      }),
+    );
+  }
+
+  _restoreUIState() {
+    const saved = localStorage.getItem(`ws_${this.workspaceId}`);
+    if (!saved) return;
+
+    const { pluginId, visualizer, params } = JSON.parse(saved);
+
+    const dataSourceSelect = document.getElementById("data-source-select");
+    if (pluginId && dataSourceSelect) {
+      dataSourceSelect.value = pluginId;
+      this._updatePluginParams(pluginId);
+
+      if (params) {
+        Object.entries(params).forEach(([name, value]) => {
+          const input = document.querySelector(
+            `#plugin-params input[name="${name}"]`,
+          );
+          if (input) input.value = value;
+        });
+      }
+    }
+
+    const visualizerSelect = document.getElementById("visualizer-select");
+    if (visualizer && visualizerSelect) {
+      visualizerSelect.value = visualizer;
+    }
   }
 
   /**
@@ -153,6 +213,7 @@ class WorkspaceController {
         option.dataset.params = JSON.stringify(source.parameters);
         select.appendChild(option);
       });
+      this._restoreUIState();
     } catch (error) {
       console.error("Failed to load data sources:", error);
     }
@@ -222,6 +283,7 @@ class WorkspaceController {
         showNotification(result.error, "error");
       } else {
         showNotification(`Loaded ${result.node_count} nodes`, "success");
+        this._saveUIState();
         await this._refreshVisualization();
       }
     } catch (error) {


### PR DESCRIPTION
This pull request adds automatic restoration and saving of workspace UI state for the graph explorer, improving user experience by persisting plugin selections, visualizer choices, and parameter values across sessions. The changes are implemented in both the Django and Flask versions of the graph explorer.

UI state persistence and restoration:

* Added `_saveUIState` and `_restoreUIState` methods to `WorkspaceController` to store and retrieve the user's plugin, visualizer, and parameter selections in `localStorage` for each workspace.
* Called `_restoreUIState` after loading data sources to automatically repopulate UI fields with the last used values.
* Invoked `_saveUIState` after successfully loading graph data, ensuring the latest UI state is saved whenever the graph is updated.

Workspace graph restoration:

* Added `_autoRestore` method to `WorkspaceController` to check for existing graph data and refresh the visualization automatically if nodes are present, restoring the workspace's visual state on load.

Closes #29 