### PR TITLE
Tests for platform and web

### DIFF
--- a/platform/tests/conftest.py
+++ b/platform/tests/conftest.py
@@ -1,0 +1,83 @@
+"""
+Shared fixtures for platform tests.
+"""
+
+import pytest
+
+from tangled_api.model import Graph, Node, Edge
+
+
+class MockDataSourcePlugin:
+    """Minimal DataSourcePlugin implementation for testing."""
+
+    @property
+    def name(self) -> str:
+        return "Mock Data Source"
+
+    @property
+    def description(self) -> str:
+        return "Mock for testing"
+
+    @property
+    def parameters(self):
+        return []
+
+    def load(self, **params) -> Graph:
+        graph = Graph(directed=True)
+        n1 = Node("n1")
+        n1.set_attribute("name", "Alice")
+        n1.set_attribute("age", 30)
+        n2 = Node("n2")
+        n2.set_attribute("name", "Bob")
+        n2.set_attribute("age", 25)
+        graph.add_node(n1)
+        graph.add_node(n2)
+        graph.add_edge(Edge("e1", "n1", "n2"))
+        return graph
+
+
+class MockVisualizerPlugin:
+    """Minimal VisualizerPlugin implementation for testing."""
+
+    @property
+    def name(self) -> str:
+        return "Mock Visualizer"
+
+    @property
+    def description(self) -> str:
+        return "Mock for testing"
+
+    def render(self, graph: Graph) -> str:
+        return f"<html>{len(graph.nodes)} nodes, {len(graph.edges)} edges</html>"
+
+
+@pytest.fixture
+def mock_data_source():
+    return MockDataSourcePlugin()
+
+
+@pytest.fixture
+def mock_visualizer():
+    return MockVisualizerPlugin()
+
+
+@pytest.fixture
+def simple_graph():
+    """Graph with 2 nodes and 1 edge for CLI/workspace tests."""
+    graph = Graph(directed=True)
+    n1 = Node(id="n1")
+    n1.set_attribute("name", "Alice")
+    n1.set_attribute("age", 30)
+    n2 = Node(id="n2")
+    n2.set_attribute("name", "Bob")
+    n2.set_attribute("age", 25)
+    graph.add_node(n1)
+    graph.add_node(n2)
+    graph.add_edge(Edge(id="e1", source_id="n1", target_id="n2"))
+    return graph
+
+
+@pytest.fixture
+def empty_graph():
+    """Empty graph for tests."""
+    return Graph(directed=True)

--- a/platform/tests/test_cli.py
+++ b/platform/tests/test_cli.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for platform CLI (tangled_platform.cli).
+"""
+
+import pytest
+
+from tangled_api.model import Graph, Node, Edge
+from tangled_platform.cli import CLI
+
+
+class TestCLI:
+    """Test platform CLI (graph-based)."""
+
+    def test_help_returns_docstring(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("help")
+        assert result
+        assert "Error:" not in result
+
+    def test_empty_command_returns_empty(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("")
+        assert result == ""
+
+    def test_unknown_command_returns_error(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("fly")
+        assert "Error:" in result
+        assert "Unknown" in result or "unknown" in result
+
+    def test_create_node_basic(self, empty_graph):
+        cli = CLI(empty_graph)
+        result = cli.execute("create node --id=x")
+        assert "Error:" not in result
+        assert "x" in empty_graph.nodes
+
+    def test_create_node_with_properties(self, empty_graph):
+        cli = CLI(empty_graph)
+        result = cli.execute("create node --id=x --property Name=Alice --property Age=25")
+        assert "Error:" not in result
+        node = empty_graph.nodes["x"]
+        assert node.get_attribute_value("Name") == "Alice"
+        assert node.get_attribute_value("Age") == 25
+
+    def test_create_node_duplicate_returns_error(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("create node --id=n1")
+        assert "Error:" in result
+        assert "already exists" in result
+
+    def test_create_edge_basic(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("create edge --id=e2 n1 n2")
+        assert "Error:" not in result
+        assert "e2" in simple_graph.edges
+
+    def test_create_edge_missing_id_returns_error(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("create edge n1 n2")
+        assert "Error:" in result
+
+    def test_edit_node(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("edit node --id=n1 --property age=99")
+        assert "Error:" not in result
+        assert simple_graph.nodes["n1"].get_attribute_value("age") == 99
+
+    def test_delete_edge_then_node(self, empty_graph):
+        cli = CLI(empty_graph)
+        cli.execute("create node --id=x")
+        cli.execute("create node --id=y")
+        cli.execute("create edge --id=e1 x y")
+        cli.execute("delete edge --id=e1")
+        result = cli.execute("delete node --id=x")
+        assert "Error:" not in result
+        assert "x" not in empty_graph.nodes
+
+    def test_delete_node_with_edges_returns_error(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("delete node --id=n1")
+        assert "Error:" in result
+        assert "edge" in result.lower()
+
+    def test_filter_basic(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("filter age > 26")
+        assert "Error:" not in result
+        assert "n1" in simple_graph.nodes
+        assert "n2" not in simple_graph.nodes
+
+    def test_filter_empty_query_returns_error(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("filter")
+        assert "Error:" in result
+
+    def test_search_by_value(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("search Alice")
+        assert "Error:" not in result
+        assert "n1" in simple_graph.nodes
+        assert "n2" not in simple_graph.nodes
+
+    def test_clear_removes_all(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("clear")
+        assert "Error:" not in result
+        assert len(simple_graph.nodes) == 0
+        assert len(simple_graph.edges) == 0
+
+    def test_show_nodes(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("show nodes")
+        assert "Error:" not in result
+        assert "n1" in result
+        assert "n2" in result
+
+    def test_show_edges(self, simple_graph):
+        cli = CLI(simple_graph)
+        result = cli.execute("show edges")
+        assert "Error:" not in result
+        assert "e1" in result

--- a/platform/tests/test_core.py
+++ b/platform/tests/test_core.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for Platform (tangled_platform.core).
+"""
+
+import pytest
+
+from tangled_platform import Platform
+
+
+class TestPlatform:
+    """Test Platform class."""
+
+    def test_create_workspace_returns_workspace(self):
+        platform = Platform()
+        ws = platform.create_workspace()
+        assert ws is not None
+        assert ws.id is not None
+
+    def test_create_workspace_with_id(self):
+        platform = Platform()
+        ws = platform.create_workspace(workspace_id="my-id")
+        assert ws.id == "my-id"
+
+    def test_get_workspace_returns_created_workspace(self):
+        platform = Platform()
+        ws = platform.create_workspace(workspace_id="w1")
+        retrieved = platform.get_workspace("w1")
+        assert retrieved is ws
+
+    def test_get_workspace_nonexistent_returns_none(self):
+        platform = Platform()
+        assert platform.get_workspace("nonexistent") is None
+
+    def test_delete_workspace_removes_workspace(self):
+        platform = Platform()
+        platform.create_workspace(workspace_id="w1")
+        deleted = platform.delete_workspace("w1")
+        assert deleted is True
+        assert platform.get_workspace("w1") is None
+
+    def test_delete_workspace_nonexistent_returns_false(self):
+        platform = Platform()
+        deleted = platform.delete_workspace("nonexistent")
+        assert deleted is False
+
+    def test_workspaces_property(self):
+        platform = Platform()
+        ws1 = platform.create_workspace(workspace_id="w1")
+        ws2 = platform.create_workspace(workspace_id="w2")
+        workspaces = platform.workspaces
+        assert "w1" in workspaces
+        assert "w2" in workspaces
+        assert workspaces["w1"] is ws1
+        assert workspaces["w2"] is ws2
+
+    def test_data_sources_property(self):
+        platform = Platform()
+        sources = platform.data_sources
+        assert isinstance(sources, dict)
+
+    def test_visualizers_property(self):
+        platform = Platform()
+        visualizers = platform.visualizers
+        assert isinstance(visualizers, dict)

--- a/platform/tests/test_registry.py
+++ b/platform/tests/test_registry.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for PluginRegistry (tangled_platform.registry).
+"""
+
+import pytest
+
+from tangled_platform import PluginRegistry
+
+
+class TestPluginRegistry:
+    """Test PluginRegistry class."""
+
+    def test_registry_initializes(self):
+        registry = PluginRegistry()
+        assert registry is not None
+
+    def test_data_sources_is_dict(self):
+        registry = PluginRegistry()
+        assert isinstance(registry.data_sources, dict)
+
+    def test_visualizers_is_dict(self):
+        registry = PluginRegistry()
+        assert isinstance(registry.visualizers, dict)
+
+    def test_get_data_source_nonexistent_returns_none(self):
+        registry = PluginRegistry()
+        result = registry.get_data_source("nonexistent_plugin_xyz")
+        assert result is None
+
+    def test_get_visualizer_nonexistent_returns_none(self):
+        registry = PluginRegistry()
+        result = registry.get_visualizer("nonexistent_visualizer_xyz")
+        assert result is None
+
+    def test_get_data_source_json_when_installed(self):
+        """When json-datasource is installed, get_data_source('json') returns plugin."""
+        registry = PluginRegistry()
+        result = registry.get_data_source("json")
+        if result is not None:
+            assert result.name == "JSON Data Source"
+
+    def test_get_visualizer_simple_when_installed(self):
+        """When simple-visualizer is installed, get_visualizer('simple') returns plugin."""
+        registry = PluginRegistry()
+        result = registry.get_visualizer("simple")
+        if result is not None:
+            assert "Simple" in result.name

--- a/platform/tests/test_workspace.py
+++ b/platform/tests/test_workspace.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for Workspace (tangled_platform.workspace).
+"""
+
+import pytest
+
+from tangled_platform import Workspace
+
+
+class TestWorkspace:
+    """Test Workspace class."""
+
+    def test_workspace_has_id(self):
+        ws = Workspace(workspace_id="w1")
+        assert ws.id == "w1"
+
+    def test_graph_initially_none(self):
+        ws = Workspace(workspace_id="w1")
+        assert ws.graph is None
+        assert ws.original_graph is None
+
+    def test_load_data_populates_graph(self, mock_data_source):
+        ws = Workspace(workspace_id="w1")
+        ws.load_data(mock_data_source)
+        assert ws.graph is not None
+        assert len(ws.graph.nodes) == 2
+        assert len(ws.graph.edges) == 1
+        assert ws.original_graph is ws.graph
+
+    def test_filter_reduces_graph(self, mock_data_source):
+        ws = Workspace(workspace_id="w1")
+        ws.load_data(mock_data_source)
+        ws.filter("age > 26")
+        assert len(ws.graph.nodes) == 1
+        assert "n1" in ws.graph.nodes
+
+    def test_filter_without_graph_raises(self):
+        ws = Workspace(workspace_id="w1")
+        with pytest.raises(ValueError, match="No graph loaded"):
+            ws.filter("age > 25")
+
+    def test_reset_restores_original(self, mock_data_source):
+        ws = Workspace(workspace_id="w1")
+        ws.load_data(mock_data_source)
+        ws.filter("age > 26")
+        assert len(ws.graph.nodes) == 1
+        ws.reset()
+        assert len(ws.graph.nodes) == 2
+        assert ws.graph is ws.original_graph
+
+    def test_render_returns_html(self, mock_data_source, mock_visualizer):
+        ws = Workspace(workspace_id="w1")
+        ws.load_data(mock_data_source)
+        html = ws.render(mock_visualizer)
+        assert "<html>" in html
+        assert "2 nodes" in html or "2" in html
+
+    def test_render_empty_graph_returns_empty_string(self, mock_visualizer):
+        ws = Workspace(workspace_id="w1")
+        html = ws.render(mock_visualizer)
+        assert html == ""

--- a/web/tests/test_services.py
+++ b/web/tests/test_services.py
@@ -1,0 +1,324 @@
+"""
+Tests for tangled_web services.
+
+Each service function accepts a Platform and request params, returns (dict, status_code).
+"""
+
+import uuid
+
+import pytest
+
+from tangled_api.model import Graph, Node, Edge
+from tangled_platform import Workspace
+from tangled_web.services import (
+    WorkspaceNotFound,
+    list_data_sources,
+    list_visualizers,
+    load_data,
+    render_graph,
+    filter_graph,
+    search_graph,
+    reset_graph,
+    execute_cli,
+    get_graph_data,
+)
+
+
+class MockDataSourcePlugin:
+    """Minimal DataSourcePlugin for testing."""
+
+    @property
+    def name(self) -> str:
+        return "Mock Data Source"
+
+    @property
+    def description(self) -> str:
+        return "Mock for testing"
+
+    @property
+    def parameters(self):
+        return []
+
+    def load(self, **params) -> Graph:
+        graph = Graph(directed=True)
+        n1 = Node(id="n1")
+        n1.set_attribute("name", "Alice")
+        n1.set_attribute("age", 30)
+        n2 = Node(id="n2")
+        n2.set_attribute("name", "Bob")
+        n2.set_attribute("age", 25)
+        graph.add_node(n1)
+        graph.add_node(n2)
+        graph.add_edge(Edge(id="e1", source_id="n1", target_id="n2"))
+        return graph
+
+
+class MockVisualizerPlugin:
+    """Minimal VisualizerPlugin for testing."""
+
+    @property
+    def name(self) -> str:
+        return "Mock Visualizer"
+
+    @property
+    def description(self) -> str:
+        return "Mock for testing"
+
+    def render(self, graph: Graph) -> str:
+        return f"<html>{len(graph.nodes)} nodes, {len(graph.edges)} edges</html>"
+
+
+class FakePlatform:
+    """Platform stub for service tests: real Workspace, mock plugins."""
+
+    def __init__(self):
+        self._workspaces = {}
+        self._data_sources = {"mock": MockDataSourcePlugin()}
+        self._visualizers = {"mock": MockVisualizerPlugin()}
+
+    @property
+    def data_sources(self):
+        return self._data_sources
+
+    @property
+    def visualizers(self):
+        return self._visualizers
+
+    def get_data_source(self, name: str):
+        return self._data_sources.get(name)
+
+    def get_visualizer(self, name: str):
+        return self._visualizers.get(name)
+
+    def create_workspace(self, workspace_id: str | None = None) -> Workspace:
+        wid = workspace_id or str(uuid.uuid4())
+        ws = Workspace(wid)
+        self._workspaces[wid] = ws
+        return ws
+
+    def get_workspace(self, workspace_id: str):
+        return self._workspaces.get(workspace_id)
+
+
+@pytest.fixture
+def platform():
+    return FakePlatform()
+
+
+@pytest.fixture
+def workspace_id(platform):
+    ws = platform.create_workspace(workspace_id="ws1")
+    return ws.id
+
+
+# ── list_data_sources ────────────────────────────────────────────────────────
+
+
+def test_list_data_sources_returns_list_and_200(platform):
+    data, status = list_data_sources(platform)
+    assert status == 200
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    item = data[0]
+    assert "id" in item
+    assert "name" in item
+    assert "description" in item
+    assert "parameters" in item
+
+
+# ── list_visualizers ─────────────────────────────────────────────────────────
+
+
+def test_list_visualizers_returns_list_and_200(platform):
+    data, status = list_visualizers(platform)
+    assert status == 200
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    item = data[0]
+    assert "id" in item
+    assert "name" in item
+    assert "description" in item
+
+
+# ── load_data ────────────────────────────────────────────────────────────────
+
+
+def test_load_data_success(platform, workspace_id):
+    data, status = load_data(
+        platform, workspace_id,
+        plugin_name="mock",
+        params={},
+    )
+    assert status == 200
+    assert data["success"] is True
+    assert data["node_count"] == 2
+
+
+def test_load_data_nonexistent_workspace_raises(platform):
+    with pytest.raises(WorkspaceNotFound):
+        load_data(platform, "nonexistent", plugin_name="mock", params={})
+
+
+def test_load_data_nonexistent_plugin_returns_404(platform, workspace_id):
+    data, status = load_data(
+        platform, workspace_id,
+        plugin_name="nonexistent",
+        params={},
+    )
+    assert status == 404
+    assert "error" in data
+
+
+def test_load_data_sets_cli_cleared_false(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    ws = platform.get_workspace(workspace_id)
+    assert ws._cli_cleared is False
+
+
+# ── render_graph ─────────────────────────────────────────────────────────────
+
+
+def test_render_graph_success(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = render_graph(platform, workspace_id, visualizer_name="mock")
+    assert status == 200
+    assert "html" in data
+    assert "<html>" in data["html"]
+    assert "2 nodes" in data["html"]
+
+
+def test_render_graph_nonexistent_workspace_raises(platform):
+    with pytest.raises(WorkspaceNotFound):
+        render_graph(platform, "nonexistent", visualizer_name="mock")
+
+
+def test_render_graph_nonexistent_visualizer_returns_404(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = render_graph(
+        platform, workspace_id,
+        visualizer_name="nonexistent",
+    )
+    assert status == 404
+    assert "error" in data
+
+
+# ── filter_graph ─────────────────────────────────────────────────────────────
+
+
+def test_filter_graph_success(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = filter_graph(platform, workspace_id, query="age > 26")
+    assert status == 200
+    assert data["success"] is True
+    assert data["node_count"] == 1
+
+
+def test_filter_graph_nonexistent_workspace_raises(platform):
+    with pytest.raises(WorkspaceNotFound):
+        filter_graph(platform, "nonexistent", query="age > 26")
+
+
+def test_filter_graph_invalid_query_returns_400(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = filter_graph(platform, workspace_id, query="invalidquery")
+    assert status == 400
+    assert "error" in data
+
+
+# ── search_graph ─────────────────────────────────────────────────────────────
+
+
+def test_search_graph_success(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = search_graph(platform, workspace_id, query="Alice")
+    assert status == 200
+    assert data["success"] is True
+
+
+def test_search_graph_nonexistent_workspace_raises(platform):
+    with pytest.raises(WorkspaceNotFound):
+        search_graph(platform, "nonexistent", query="x")
+
+
+# ── reset_graph ──────────────────────────────────────────────────────────────
+
+
+def test_reset_graph_success(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    filter_graph(platform, workspace_id, query="age > 26")
+    data, status = reset_graph(platform, workspace_id)
+    assert status == 200
+    assert data["success"] is True
+
+
+def test_reset_graph_restores_node_count(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    filter_graph(platform, workspace_id, query="age > 26")
+    ws = platform.get_workspace(workspace_id)
+    assert len(ws.graph.nodes) == 1
+    reset_graph(platform, workspace_id)
+    assert len(ws.graph.nodes) == 2
+
+
+def test_reset_graph_sets_cli_cleared_false(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    ws = platform.get_workspace(workspace_id)
+    ws._cli_cleared = True
+    reset_graph(platform, workspace_id)
+    assert ws._cli_cleared is False
+
+
+def test_reset_graph_nonexistent_workspace_raises(platform):
+    with pytest.raises(WorkspaceNotFound):
+        reset_graph(platform, "nonexistent")
+
+
+# ── get_graph_data ───────────────────────────────────────────────────────────
+
+
+def test_get_graph_data_success(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = get_graph_data(platform, workspace_id)
+    assert status == 200
+    assert "nodes" in data
+    assert "edges" in data
+    assert "directed" in data
+    assert len(data["nodes"]) == 2
+    assert len(data["edges"]) == 1
+
+
+def test_get_graph_data_nonexistent_workspace_raises(platform):
+    with pytest.raises(WorkspaceNotFound):
+        get_graph_data(platform, "nonexistent")
+
+
+def test_get_graph_data_empty_workspace_returns_empty(platform, workspace_id):
+    data, status = get_graph_data(platform, workspace_id)
+    assert status == 200
+    assert data["nodes"] == []
+    assert data["edges"] == []
+
+
+# ── execute_cli ──────────────────────────────────────────────────────────────
+
+
+def test_execute_cli_success(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = execute_cli(
+        platform, workspace_id,
+        command="show nodes",
+    )
+    assert status == 200
+    assert "result" in data
+
+
+def test_execute_cli_empty_command_returns_400(platform, workspace_id):
+    load_data(platform, workspace_id, plugin_name="mock", params={})
+    data, status = execute_cli(platform, workspace_id, command="")
+    assert status == 400
+    assert "error" in data
+
+
+def test_execute_cli_nonexistent_workspace_raises(platform):
+    with pytest.raises(WorkspaceNotFound):
+        execute_cli(platform, "nonexistent", command="show nodes")


### PR DESCRIPTION
closes #48 

This pull request introduces comprehensive unit and integration tests for the `tangled_platform` and `tangled_web` components. It adds test coverage for the core platform logic, plugin registry, workspace management, CLI functionality, and web service endpoints. The changes include the creation of shared fixtures and multiple mock plugin implementations to facilitate isolated and reliable testing.

**Platform and Workspace Testing:**

* Added unit tests for the `Platform` class, covering workspace creation, retrieval, deletion, and properties. (`platform/tests/test_core.py`)
* Added unit tests for the `Workspace` class, including graph loading, filtering, reset, and rendering with mock plugins. (`platform/tests/test_workspace.py`)

**Plugin Registry Testing:**

* Added tests for the `PluginRegistry`, verifying data source and visualizer registration, lookup, and behavior with missing plugins. (`platform/tests/test_registry.py`)

**CLI Testing:**

* Added unit tests for the platform CLI, covering command parsing, node/edge creation and deletion, filtering, searching, and error handling. (`platform/tests/test_cli.py`)

**Web Services Testing:**

* Added integration-style tests for all major `tangled_web.services` endpoints, including data source and visualizer listing, data loading, rendering, filtering, searching, CLI execution, and error scenarios. (`web/tests/test_services.py`)

**Shared Test Fixtures:**

* Introduced shared pytest fixtures and mock plugin classes to support consistent and reusable test setups across platform tests. (`platform/tests/conftest.py`)