### PR TITLE
Add SVG favicon, update templates, and implement drag-to-pan

### DIFF
--- a/graph-explorer-django/src/tangled_django/explorer/static/css/workspace.css
+++ b/graph-explorer-django/src/tangled_django/explorer/static/css/workspace.css
@@ -288,7 +288,6 @@
     position: absolute;
     border: 1.5px solid #40C9FF;
     background-color: rgba(64, 201, 255, 0.06);
-    pointer-events: none;
     border-radius: 2px;
 }
 

--- a/graph-explorer-django/src/tangled_django/explorer/static/favicon.svg
+++ b/graph-explorer-django/src/tangled_django/explorer/static/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="pool" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#40c9ff"/>
+      <stop offset="100%" stop-color="#7dddff"/>
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="16" r="16" fill="url(#pool)"/>
+  <g transform="translate(4, 4) scale(1)">
+    <circle cx="12" cy="5" r="2" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="5" cy="19" r="2" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="19" cy="19" r="2" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="12" y1="7" x2="5" y2="17" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="12" y1="7" x2="19" y2="17" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="5" y1="19" x2="19" y2="19" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/graph-explorer-django/src/tangled_django/explorer/static/js/birdview.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/birdview.js
@@ -21,7 +21,13 @@ class BirdView {
     this.mainViewHeight = 0;
 
     this.onNodeSelect = null;
+    this.onViewportDrag = null;
     this.selectedNodeId = null;
+
+    // Cached from updateViewport for drag-to-pan conversion
+    this._lastTransform = d3.zoomIdentity;
+    this._mainWidth = 0;
+    this._mainHeight = 0;
   }
 
   /**
@@ -50,7 +56,47 @@ class BirdView {
       .attr("fill", "rgba(74, 144, 217, 0.1)")
       .attr("stroke", "#4a90d9")
       .attr("stroke-width", 1.5)
-      .attr("pointer-events", "none");
+      .attr("cursor", "move")
+      .attr("pointer-events", "all")
+      .call(
+        d3
+          .drag()
+          .on("start", () => {})
+          .on("drag", (event) => this._onViewportDrag(event))
+          .on("end", () => {}),
+      );
+  }
+
+  /**
+   * Handle viewport rect drag: convert Bird View position to Main View transform
+   * @param {object} event - D3 drag event
+   */
+  _onViewportDrag(event) {
+    if (!this.onViewportDrag || !this.viewportRect) return;
+
+    const width = this.container.clientWidth;
+    const height = this.container.clientHeight;
+    const rectX = parseFloat(this.viewportRect.attr("x")) || 0;
+    const rectY = parseFloat(this.viewportRect.attr("y")) || 0;
+    const rectWidth = parseFloat(this.viewportRect.attr("width")) || 50;
+    const rectHeight = parseFloat(this.viewportRect.attr("height")) || 50;
+
+    let newRectX = rectX + event.dx;
+    let newRectY = rectY + event.dy;
+
+    newRectX = Math.max(0, Math.min(width - rectWidth, newRectX));
+    newRectY = Math.max(0, Math.min(height - rectHeight, newRectY));
+
+    this.viewportRect.attr("x", newRectX).attr("y", newRectY);
+
+    const visibleX = (newRectX - this.offsetX) / this.scale;
+    const visibleY = (newRectY - this.offsetY) / this.scale;
+    const k = this._lastTransform.k;
+    const newX = -visibleX * k;
+    const newY = -visibleY * k;
+
+    const newTransform = d3.zoomIdentity.translate(newX, newY).scale(k);
+    this.onViewportDrag(newTransform);
   }
 
   /**
@@ -149,6 +195,10 @@ class BirdView {
    */
   updateViewport(transform, mainWidth, mainHeight) {
     if (!this.viewportRect) return;
+
+    this._lastTransform = transform;
+    this._mainWidth = mainWidth;
+    this._mainHeight = mainHeight;
 
     // Inverse of main view transform to get visible area
     const visibleWidth = mainWidth / transform.k;

--- a/graph-explorer-django/src/tangled_django/explorer/static/js/workspace.js
+++ b/graph-explorer-django/src/tangled_django/explorer/static/js/workspace.js
@@ -193,6 +193,16 @@ class WorkspaceController {
         container.clientHeight,
       );
     };
+
+    // Bird View drag-to-pan: apply transform to Main View
+    this.birdView.onViewportDrag = (transform) => {
+      if (this.graphRenderer.svg && this.graphRenderer.zoom) {
+        this.graphRenderer.svg.call(
+          this.graphRenderer.zoom.transform,
+          transform,
+        );
+      }
+    };
     this.graphRenderer.onSimulationTick = (data) => {
       this.birdView.render(data);
     };
@@ -322,13 +332,8 @@ class WorkspaceController {
 
         if (graphData.nodes.length > 0) {
           if (existingSvg) {
-            console.log("calling attach...");
             this.graphRenderer.attach(existingSvg.id, graphData);
-          } else {
-            console.log("NO SVG FOUND");
           }
-        } else {
-          console.log("NO NODES");
         }
 
         this.birdView.render(this.graphData);

--- a/graph-explorer-django/src/tangled_django/explorer/templates/explorer/base.html
+++ b/graph-explorer-django/src/tangled_django/explorer/templates/explorer/base.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" type="image/svg+xml" href="{% static 'favicon.svg' %}">
     <title>{% block title %}Tangled Graph Explorer{% endblock %}</title>
 
     <!-- Tailwind CSS v4 (Browser) -->

--- a/graph-explorer-django/src/tangled_django/explorer/templates/explorer/base.html
+++ b/graph-explorer-django/src/tangled_django/explorer/templates/explorer/base.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/svg+xml" href="{% static 'favicon.svg' %}">
-    <title>{% block title %}Tangled Graph Explorer{% endblock %}</title>
+    <title>{% block title %}Tangled{% endblock %}</title>
 
     <!-- Tailwind CSS v4 (Browser) -->
     <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>

--- a/graph-explorer-django/src/tangled_django/explorer/templates/explorer/index.html
+++ b/graph-explorer-django/src/tangled_django/explorer/templates/explorer/index.html
@@ -1,6 +1,6 @@
 {% extends "explorer/base.html" %}
 
-{% block title %}Home — Tangled Graph Explorer{% endblock %}
+{% block title %}Home | Tangled{% endblock %}
 
 {% block content %}
 <div class="max-w-5xl mx-auto py-4 px-2 space-y-6">

--- a/graph-explorer-django/src/tangled_django/explorer/templates/explorer/workspace.html
+++ b/graph-explorer-django/src/tangled_django/explorer/templates/explorer/workspace.html
@@ -1,7 +1,7 @@
 {% extends "explorer/base.html" %}
 {% load static %}
 
-{% block title %}Workspace — Tangled Graph Explorer{% endblock %}
+{% block title %}Workspace | Tangled{% endblock %}
 
 {% block head %}
 <link rel="stylesheet" href="{% static 'css/workspace.css' %}">

--- a/graph-explorer/src/tangled_graph_explorer/static/css/workspace.css
+++ b/graph-explorer/src/tangled_graph_explorer/static/css/workspace.css
@@ -317,7 +317,6 @@
   position: absolute;
   border: 1.5px solid #40c9ff;
   background-color: rgba(64, 201, 255, 0.06);
-  pointer-events: none;
   border-radius: 2px;
 }
 

--- a/graph-explorer/src/tangled_graph_explorer/static/favicon.svg
+++ b/graph-explorer/src/tangled_graph_explorer/static/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="pool" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#40c9ff"/>
+      <stop offset="100%" stop-color="#7dddff"/>
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="16" r="16" fill="url(#pool)"/>
+  <g transform="translate(4, 4) scale(1)">
+    <circle cx="12" cy="5" r="2" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="5" cy="19" r="2" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="19" cy="19" r="2" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="12" y1="7" x2="5" y2="17" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="12" y1="7" x2="19" y2="17" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="5" y1="19" x2="19" y2="19" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/graph-explorer/src/tangled_graph_explorer/static/js/birdview.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/birdview.js
@@ -21,7 +21,13 @@ class BirdView {
     this.mainViewHeight = 0;
 
     this.onNodeSelect = null;
+    this.onViewportDrag = null;
     this.selectedNodeId = null;
+
+    // Cached from updateViewport for drag-to-pan conversion
+    this._lastTransform = d3.zoomIdentity;
+    this._mainWidth = 0;
+    this._mainHeight = 0;
   }
 
   /**
@@ -50,7 +56,47 @@ class BirdView {
       .attr("fill", "rgba(74, 144, 217, 0.1)")
       .attr("stroke", "#4a90d9")
       .attr("stroke-width", 1.5)
-      .attr("pointer-events", "none");
+      .attr("cursor", "move")
+      .attr("pointer-events", "all")
+      .call(
+        d3
+          .drag()
+          .on("start", () => {})
+          .on("drag", (event) => this._onViewportDrag(event))
+          .on("end", () => {}),
+      );
+  }
+
+  /**
+   * Handle viewport rect drag: convert Bird View position to Main View transform
+   * @param {object} event - D3 drag event
+   */
+  _onViewportDrag(event) {
+    if (!this.onViewportDrag || !this.viewportRect) return;
+
+    const width = this.container.clientWidth;
+    const height = this.container.clientHeight;
+    const rectX = parseFloat(this.viewportRect.attr("x")) || 0;
+    const rectY = parseFloat(this.viewportRect.attr("y")) || 0;
+    const rectWidth = parseFloat(this.viewportRect.attr("width")) || 50;
+    const rectHeight = parseFloat(this.viewportRect.attr("height")) || 50;
+
+    let newRectX = rectX + event.dx;
+    let newRectY = rectY + event.dy;
+
+    newRectX = Math.max(0, Math.min(width - rectWidth, newRectX));
+    newRectY = Math.max(0, Math.min(height - rectHeight, newRectY));
+
+    this.viewportRect.attr("x", newRectX).attr("y", newRectY);
+
+    const visibleX = (newRectX - this.offsetX) / this.scale;
+    const visibleY = (newRectY - this.offsetY) / this.scale;
+    const k = this._lastTransform.k;
+    const newX = -visibleX * k;
+    const newY = -visibleY * k;
+
+    const newTransform = d3.zoomIdentity.translate(newX, newY).scale(k);
+    this.onViewportDrag(newTransform);
   }
 
   /**
@@ -149,6 +195,10 @@ class BirdView {
    */
   updateViewport(transform, mainWidth, mainHeight) {
     if (!this.viewportRect) return;
+
+    this._lastTransform = transform;
+    this._mainWidth = mainWidth;
+    this._mainHeight = mainHeight;
 
     // Inverse of main view transform to get visible area
     const visibleWidth = mainWidth / transform.k;

--- a/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
+++ b/graph-explorer/src/tangled_graph_explorer/static/js/workspace.js
@@ -193,6 +193,16 @@ class WorkspaceController {
         container.clientHeight,
       );
     };
+
+    // Bird View drag-to-pan: apply transform to Main View
+    this.birdView.onViewportDrag = (transform) => {
+      if (this.graphRenderer.svg && this.graphRenderer.zoom) {
+        this.graphRenderer.svg.call(
+          this.graphRenderer.zoom.transform,
+          transform,
+        );
+      }
+    };
     this.graphRenderer.onSimulationTick = (data) => {
       this.birdView.render(data);
     };
@@ -322,13 +332,8 @@ class WorkspaceController {
 
         if (graphData.nodes.length > 0) {
           if (existingSvg) {
-            console.log("calling attach...");
             this.graphRenderer.attach(existingSvg.id, graphData);
-          } else {
-            console.log("NO SVG FOUND");
           }
-        } else {
-          console.log("NO NODES");
         }
 
         this.birdView.render(this.graphData);

--- a/graph-explorer/src/tangled_graph_explorer/templates/base.html
+++ b/graph-explorer/src/tangled_graph_explorer/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}" />
-    <title>{% block title %}Tangled Graph Explorer{% endblock %}</title>
+    <title>{% block title %}Tangled{% endblock %}</title>
 
     <!-- Tailwind CSS v4 (Browser) -->
     <script

--- a/graph-explorer/src/tangled_graph_explorer/templates/base.html
+++ b/graph-explorer/src/tangled_graph_explorer/templates/base.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}" />
     <title>{% block title %}Tangled Graph Explorer{% endblock %}</title>
 
     <!-- Tailwind CSS v4 (Browser) -->

--- a/graph-explorer/src/tangled_graph_explorer/templates/index.html
+++ b/graph-explorer/src/tangled_graph_explorer/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home — Tangled Graph Explorer{% endblock %}
+{% block title %}Home | Tangled{% endblock %}
 
 {% block content %}
 <div class="max-w-5xl mx-auto py-4 px-2 space-y-6">

--- a/graph-explorer/src/tangled_graph_explorer/templates/workspace.html
+++ b/graph-explorer/src/tangled_graph_explorer/templates/workspace.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Workspace — Tangled Graph Explorer{% endblock %}
+{% block title %}Workspace | Tangled{% endblock %}
 
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/workspace.css') }}">


### PR DESCRIPTION
This pull request introduces a new drag-to-pan feature for the "Bird View" (minimap) in the workspace, allowing users to pan the main graph view by dragging the viewport rectangle in the minimap. It also includes several UI polish updates, such as updating page titles and adding favicons. Some minor code cleanup is also performed.

**Bird View (Minimap) Drag-to-Pan Feature:**

- Added support for dragging the viewport rectangle in the Bird View to pan the main graph view in both Django and Flask codebases. This includes:
  - Making the viewport rectangle draggable and updating its cursor style.
  - Calculating and applying the corresponding transform to the main view when the rectangle is dragged.
  - Wiring up the drag event so that the main view updates in real time as the minimap rectangle moves. [[1]](diffhunk://#diff-6522ddabe0656fb2ba23ef19e3007e1647aa918b0ff6ee94fa72769c6f84a929R24-R30) [[2]](diffhunk://#diff-6522ddabe0656fb2ba23ef19e3007e1647aa918b0ff6ee94fa72769c6f84a929L53-R99) [[3]](diffhunk://#diff-6522ddabe0656fb2ba23ef19e3007e1647aa918b0ff6ee94fa72769c6f84a929R199-R202) [[4]](diffhunk://#diff-dc0d6bedef9c27d83e271dac1beae059bc1b48ee4f086b68405fa0cce74d356eR196-R205) [[5]](diffhunk://#diff-67a2759e6dfa6ec1fa84fd23f433a98fa32a2255f5c49abb33358b3acf9cbe94L291) [[6]](diffhunk://#diff-970bce9bb308efe8f9703b27c428bb1119e53905aa8eef61c2d8be9a427657e0L320)

**UI/UX Improvements:**

- Updated all page titles to use a simplified "Tangled" naming scheme and replaced em dashes with vertical bars for consistency. [[1]](diffhunk://#diff-2cf34e85e3390be09560726a7f9bc78d0bccbac9a0d201559315dc6eaef2f1d8L7-R8) [[2]](diffhunk://#diff-e6c071f503263838bad3b508962147787e23455b0a38651152a319d0173f8ac3L3-R3) [[3]](diffhunk://#diff-2d4d7923c88d30987c391f8ae022f8f8362a085b163b962afb2a05e377e7c2b7L4-R4) [[4]](diffhunk://#diff-b5439f7d7afa13b9050e1773f607acae772ef18b6cf09d9e21d2a36cd9d408faL6-R7) [[5]](diffhunk://#diff-b6946d4ae20dbbc1d7dcae85e324539f1dd9ba1c726f38b79151e33ff940be60L3-R3) [[6]](diffhunk://#diff-febc6e64661eef3a6e8975324d9f70373c843519cf96db3ce24d3e4912a03f45L3-R3)
- Added a favicon to both Django and Flask base templates for improved branding. [[1]](diffhunk://#diff-2cf34e85e3390be09560726a7f9bc78d0bccbac9a0d201559315dc6eaef2f1d8L7-R8) [[2]](diffhunk://#diff-b5439f7d7afa13b9050e1773f607acae772ef18b6cf09d9e21d2a36cd9d408faL6-R7)

**Code Cleanup:**

- Removed unnecessary `console.log` statements from the workspace controller for cleaner output.

These changes collectively enhance the usability and polish of the workspace graph explorer, making navigation smoother and the UI more consistent.