### PR TITLE
Improve component handling and organize unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ run-django:
 	$(VENV) python graph-explorer-django/manage.py runserver 0.0.0.0:$(PORT)
 
 test:
-	$(VENV) pip install -q -e "./api[dev]" -e "./platform[dev]" -e "./json-datasource[dev]" -e "./yaml-datasource[dev]" -e "./kuzu-datasource[dev]" && \
-	$(VENV) pytest api/src/tests/ json-datasource/tests/ yaml-datasource/tests/ kuzu-datasource/tests/ -v
+	$(VENV) pip install -q $$(find . -maxdepth 1 -mindepth 1 -type d ! -name venv ! -name .git ! -name docs ! -name scripts ! -name .mypy_cache ! -name .pytest_cache ! -name .cursor -exec test -f {}/pyproject.toml \; -printf ' -e "./%f[dev]"') && \
+	$(VENV) pytest $$(find . -maxdepth 3 -type d -name tests ! -path './venv/*' ! -path './.git/*' | sort) -v
 
 lint:
 	$(VENV) pip install -q -e "./api[dev]" -e "./platform[dev]" && \

--- a/api/tests/graph_test.py
+++ b/api/tests/graph_test.py
@@ -1,7 +1,7 @@
 """
 Unit tests for Graph data model.
 
-Run with: python -m pytest graph_test.py -v
+Run with: pytest api/tests/ -v
 """
 
 import pytest

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -77,11 +77,12 @@ Write-Host ""
 
 # Discover components: direct subdirs with pyproject.toml, order api → platform → others (sorted) → graph-explorer
 $middle = Get-ChildItem -Directory | Where-Object {
-    $_.Name -notin @("api", "platform", "graph-explorer", "venv") -and
+    $_.Name -notin @("api", "platform", "graph-explorer", "graph-explorer-django", "venv") -and
     (Test-Path (Join-Path $_.FullName "pyproject.toml"))
 } | Select-Object -ExpandProperty Name | Sort-Object
 $componentDirs = @("api", "platform") + [array]$middle
 if (Test-Path ".\graph-explorer\pyproject.toml") { $componentDirs += "graph-explorer" }
+if (Test-Path ".\graph-explorer-django\pyproject.toml") { $componentDirs += "graph-explorer-django" }
 $componentPaths = $componentDirs | ForEach-Object { ".\$_" }
 
 # Get package name from pyproject.toml (fallback: tangled-<dirname>)

--- a/scripts/reinstall.ps1
+++ b/scripts/reinstall.ps1
@@ -21,11 +21,12 @@ $pip = ".\venv\Scripts\pip.exe"
 
 # Discover components (same order as install.ps1): api → platform → others (sorted) → graph-explorer
 $middle = Get-ChildItem -Directory | Where-Object {
-    $_.Name -notin @("api", "platform", "graph-explorer", "venv") -and
+    $_.Name -notin @("api", "platform", "graph-explorer", "graph-explorer-django", "venv") -and
     (Test-Path (Join-Path $_.FullName "pyproject.toml"))
 } | Select-Object -ExpandProperty Name | Sort-Object
 $componentDirs = @("api", "platform") + [array]$middle
 if (Test-Path ".\graph-explorer\pyproject.toml") { $componentDirs += "graph-explorer" }
+if (Test-Path ".\graph-explorer-django\pyproject.toml") { $componentDirs += "graph-explorer-django" }
 $componentPaths = $componentDirs | ForEach-Object { ".\$_" }
 
 # Get package name from pyproject.toml (fallback: tangled-<dirname>)

--- a/simple-visualizer/src/tangled_simple_visualizer/plugin.py
+++ b/simple-visualizer/src/tangled_simple_visualizer/plugin.py
@@ -44,7 +44,6 @@ class SimpleVisualizer(VisualizerPlugin):
                 "id": node_id,
                 "label": label
             })
-            print(node)
 
         edges = []
         for edge_id, edge in graph.edges.items():


### PR DESCRIPTION
This pull request improves the automation and consistency of test discovery and component installation across the project, and makes a minor cleanup to the visualizer plugin. The most significant changes streamline how Python packages are discovered and installed in both Makefile and PowerShell scripts, and standardize test locations and instructions.

**Automation and consistency improvements:**

* The `Makefile`'s `test` target now automatically discovers all Python components (by finding directories with `pyproject.toml`) and installs them with their development dependencies, rather than listing them manually. Test discovery is also automated to include all `tests` directories up to three levels deep.
* The PowerShell scripts `install.ps1` and `reinstall.ps1` now include `graph-explorer-django` in the set of components to install if it exists, ensuring all relevant components are handled consistently. [[1]](diffhunk://#diff-49e87bd475b9a24c9b32cbaa247e494097aa436fff27877e2b7777f2c5ac829bL80-R85) [[2]](diffhunk://#diff-f7b1be32e9f91b20db51ab1ea910edb8d0d47be186058095d00620e7f9295ceaL24-R29)

**Testing improvements:**

* The `graph_test.py` file has been moved from `api/src/tests/` to `api/tests/` and its run instructions updated, helping to standardize test locations and usage across the project.

**Minor cleanup:**

* A stray `print(node)` statement was removed from `simple-visualizer/src/tangled_simple_visualizer/plugin.py` for cleaner output.